### PR TITLE
Post field report

### DIFF
--- a/app/assets/scripts/actions/index.js
+++ b/app/assets/scripts/actions/index.js
@@ -1,9 +1,13 @@
 'use strict';
-import { fetchJSON, withToken } from '../utils/network';
+import {
+  fetchJSON,
+  withToken,
+  createResource
+} from '../utils/network';
 
 export const TOKEN = 'TOKEN';
 export function getAuthToken (username, password) {
-  return fetchJSON('get_auth_token', TOKEN, {
+  return fetchJSON(null, 'get_auth_token', TOKEN, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ username, password })
@@ -15,7 +19,17 @@ export function logoutUser () {
   return { type: LOGOUT_USER };
 }
 
+export const FIELD_REPORT_SCHEMA = 'FIELD_REPORT_SCHEMA';
+export function getFieldReportSchema () {
+  return fetchJSON(null, 'api/v1/field_report/schema/', FIELD_REPORT_SCHEMA, withToken());
+}
+
 export const GET_FIELD_REPORT = 'GET_FIELD_REPORT';
 export function getFieldReportById (id) {
-  return fetchJSON(`api/v1/field_report/${id}`, GET_FIELD_REPORT, withToken());
+  return fetchJSON(id, `api/v1/field_report/${id}`, GET_FIELD_REPORT, withToken());
+}
+
+export const CREATE_FIELD_REPORT = 'CREATE_FIELD_REPORT';
+export function createFieldReport (payload) {
+  return createResource('api/v1/field_report/', CREATE_FIELD_REPORT, payload, withToken());
 }

--- a/app/assets/scripts/main.js
+++ b/app/assets/scripts/main.js
@@ -17,6 +17,9 @@ import Register from './views/register';
 import RecoverAccount from './views/recover-account';
 import UhOh from './views/uhoh';
 
+// Field report Views
+import FieldReportForm from './views/field-report/form';
+
 polyfill();
 
 // Route available only if the user is not logged in.
@@ -61,6 +64,7 @@ const Root = () => (
         <Route exact path="/" component={Home}/>
         <Route exact path="/about" component={About}/>
         <PrivateRoute exact path="/account" component={Account}/>
+        <PrivateRoute exact path="/field-reports" component={FieldReportForm}/>
         <AnonymousRoute exact path="/login" component={Login}/>
         <AnonymousRoute exact path="/register" component={Register}/>
         <AnonymousRoute exact path="/recover-account" component={RecoverAccount}/>

--- a/app/assets/scripts/reducers/field-report-detail.js
+++ b/app/assets/scripts/reducers/field-report-detail.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const initialState = {};
+
+export default function reducer (state = initialState, action) {
+  switch (action.type) {
+    case 'GET_FIELD_REPORT':
+      return Object.assign({}, state, {
+        [action.id]: {
+          error: null,
+          fetching: true,
+          fetched: false
+        }
+      });
+    case 'GET_FIELD_REPORT_FAILED':
+      state = Object.assign({}, state, {
+        [action.id]: {
+          fetching: false,
+          fetched: true,
+          receivedAt: action.receivedAt,
+          error: action.error
+        }
+      });
+      break;
+    case 'GET_FIELD_REPORT_SUCCESS':
+      state = Object.assign({}, state, {
+        [action.id]: {
+          fetching: false,
+          fetched: true,
+          receivedAt: action.receivedAt,
+          data: action.data
+        }
+      });
+      break;
+  }
+  return state;
+}

--- a/app/assets/scripts/reducers/field-report-schema.js
+++ b/app/assets/scripts/reducers/field-report-schema.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const initialState = {
+  fetching: false,
+  fetched: false,
+  receivedAt: null,
+  data: {}
+};
+
+export default function reducer (state = initialState, action) {
+  switch (action.type) {
+    case 'FIELD_REPORT_SCHEMA_INFLIGHT':
+      return Object.assign({}, state, { error: null, fetching: true, fetched: false });
+    case 'FIELD_REPORT_SCHEMA_FAILED':
+      state = Object.assign({}, state, {
+        fetching: false,
+        fetched: true,
+        receivedAt: action.receivedAt,
+        error: action.error
+      });
+      break;
+    case 'FIELD_REPORT_SCHEMA_SUCCESS':
+      state = Object.assign({}, state, {
+        fetching: false,
+        fetched: true,
+        receivedAt: action.receivedAt,
+        data: action.data
+      });
+      break;
+  }
+  return state;
+}

--- a/app/assets/scripts/reducers/index.js
+++ b/app/assets/scripts/reducers/index.js
@@ -2,9 +2,13 @@
 import { combineReducers } from 'redux';
 
 import user from './user';
+import fieldReportSchema from './field-report-schema';
+import fieldReportDetail from './field-report-detail';
 
 export const reducers = {
-  user
+  user,
+  fieldReportSchema,
+  fieldReportDetail
 };
 
 export default combineReducers(reducers);

--- a/app/assets/scripts/utils/network.js
+++ b/app/assets/scripts/utils/network.js
@@ -28,10 +28,24 @@ function failed (action) {
   return action + '_FAILED';
 }
 
-export function fetchJSON (path, action, options) {
+export function fetchJSON (...args) {
+  return makeRequest(...args);
+}
+
+export function createResource (path, action, payload, options) {
+  options = options || {};
+  options.headers = options.headers || {};
+  options.headers['Content-Type'] = 'application/json';
+  options.headers['Accept'] = 'application/json';
+  options.method = 'POST';
+  options.body = JSON.stringify(payload);
+  return makeRequest(null, path, action, options);
+}
+
+function makeRequest (id, path, action, options) {
   options = options || {};
   return function (dispatch) {
-    dispatch({ type: inflight(action) });
+    dispatch({ type: inflight(action), id });
     fetch(url.resolve(api, path), options)
       .then(response => {
         return response.text()
@@ -58,10 +72,10 @@ export function fetchJSON (path, action, options) {
         });
       })
       .then(data => {
-        dispatch({ type: success(action), data, receivedAt: Date.now() });
+        dispatch({ type: success(action), data, receivedAt: Date.now(), id });
       })
       .catch(error => {
-        dispatch({ type: failed(action), error });
+        dispatch({ type: failed(action), error, id });
       });
   };
 }

--- a/app/assets/scripts/views/field-report/form.js
+++ b/app/assets/scripts/views/field-report/form.js
@@ -1,0 +1,102 @@
+'use strict';
+
+import React from 'react';
+import { connect } from 'react-redux';
+import { PropTypes as T } from 'prop-types';
+import { get } from 'object-path';
+import {
+  getFieldReportSchema,
+  getFieldReportById,
+  createFieldReport
+} from '../../actions';
+
+const fixture = {
+  action: 'LRC Svannakhet branch closely coordinated with PDMC and other stakeholders in collecting information data in flooding areas',
+  created_at: new Date(),
+  description: 'Heavy rain over parts of the country is the result of a trough of low  pressure combined with the northwest monsoon flowing through Laos.',
+  dtype: {
+    id: 7
+  },
+  countries: [{
+    id: 12
+  }],
+  num_affected: 1000,
+  num_assisted_gov: 50,
+  num_assisted_rc: 150,
+  num_dead: 25,
+  num_displaced: 55,
+  num_expats_delegates: 0,
+  num_injured: 2,
+  num_localstaff: 50,
+  num_missing: 0,
+  num_volunteers: 5,
+  request_assistance: true,
+  rid: 5,
+  status: 2,
+  summary: ''
+};
+
+// arbitrary field report to tie action creater and state to.
+const reportPK = 15;
+
+class FieldReportForm extends React.Component {
+  constructor () {
+    super();
+    this.postFixture = this.postFixture.bind(this);
+  }
+
+  componentWillMount () {
+    this.props._getSchema();
+    this.props._getReport();
+  }
+
+  postFixture () {
+    this.props._createReport(fixture);
+  }
+
+  render () {
+    return (
+      <div>
+        <h2>Fixture</h2>
+        <button onClick={this.postFixture}>Post!</button>
+        <pre>{JSON.stringify(fixture, null, '\t')}</pre>
+
+        {this.props.report.fetched && !this.props.report.error ? ([
+          <h2 key='title'>Report {reportPK}</h2>,
+          <pre key='data'>{JSON.stringify(this.props.report.data, null, '\t')}</pre>
+        ]) : null}
+
+        {this.props.schema.fetched && !this.props.schema.error ? ([
+          <h2 key='title'>Schema</h2>,
+          <pre key='data'>{JSON.stringify(this.props.schema.data.fields, null, '\t')}</pre>
+        ]) : null}
+      </div>
+    );
+  }
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  FieldReportForm.propTypes = {
+    _getReport: T.func,
+    _getSchema: T.func,
+    _createReport: T.func,
+    report: T.object,
+    schema: T.object
+  };
+}
+
+// /////////////////////////////////////////////////////////////////// //
+// Connect functions
+
+const selector = (state) => ({
+  report: get(state.fieldReportDetail, reportPK, {}),
+  schema: state.fieldReportSchema
+});
+
+const dispatcher = (dispatch) => ({
+  _getReport: () => dispatch(getFieldReportById(reportPK)),
+  _getSchema: () => dispatch(getFieldReportSchema()),
+  _createReport: (...args) => dispatch(createFieldReport(...args))
+});
+
+export default connect(selector, dispatcher)(FieldReportForm);

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "lodash.clonedeep": "^4.5.0",
     "lodash.defaultsdeep": "^4.6.0",
     "lodash.set": "^4.3.2",
+    "object-path": "^0.11.4",
     "prop-types": "^15.6.0",
     "react": "^16.1.0",
     "react-dom": "^16.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5001,6 +5001,10 @@ object-keys@^1.0.6, object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
 
+object-path@^0.11.4:
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.11.4.tgz#370ae752fbf37de3ea70a861c23bba8915691949"
+
 object-path@^0.9.0:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.9.2.tgz#0fd9a74fc5fad1ae3968b586bda5c632bd6c05a5"


### PR DESCRIPTION
@danielfdsilva This adds a dummy page that requests the field report schema, requests a hard-coded field report, and includes a fixture that you can instantly `POST` to the api. It also includes all the action creators and state objects you need to do that.

On creating records, apparently the framework we're using will accept input more or less the way it serves it, so for future reference doing a read on a current record should be a good indicator for how to structure the payload.

When you get to rendering forms for the Countries selector and the Disaster Type selectors, the data for those can be found here: https://github.com/IFRCGo/go-api/tree/develop/api/fixtures

Those are unlikely to change so I would just pull them into this codebase to use to generate dropdowns or whatever other form element we need.

For this particular model, many of the fields are optional. For the few that aren't optional, either consult the schema, or check the model here: https://github.com/IFRCGo/go-api/blob/develop/api/models.py#L73. `null=True` or `blank=True` means it's optional.