### PR TITLE
Polyfill es6, not just promises

### DIFF
--- a/app/assets/scripts/main.js
+++ b/app/assets/scripts/main.js
@@ -1,10 +1,10 @@
 'use strict';
+import 'babel-polyfill';
 import React from 'react';
 import { PropTypes as T } from 'prop-types';
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';
 import { BrowserRouter as Router, Route, Switch, Redirect } from 'react-router-dom';
-import { polyfill } from 'es6-promise';
 
 import store from './utils/store';
 
@@ -24,7 +24,6 @@ import AdminArea from './views/admin-area';
 import Deployments from './views/deployments';
 import HeOps from './views/heops';
 
-polyfill();
 require('isomorphic-fetch');
 
 // Route available only if the user is not logged in.

--- a/package.json
+++ b/package.json
@@ -97,8 +97,8 @@
   "dependencies": {
     "ajv": "^5.3.0",
     "ajv-keywords": "^2.1.1",
+    "babel-polyfill": "^6.26.0",
     "classnames": "^2.2.5",
-    "es6-promise": "^4.1.1",
     "isomorphic-fetch": "^2.2.1",
     "local-storage": "^1.4.2",
     "lodash.clonedeep": "^4.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -797,6 +797,14 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
+babel-polyfill@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.26.0.tgz#379937abc67d7895970adc621f284cd966cf2153"
+  dependencies:
+    babel-runtime "^6.26.0"
+    core-js "^2.5.0"
+    regenerator-runtime "^0.10.5"
+
 babel-preset-es2015@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz#d44050d6bc2c9feea702aaf38d727a0210538939"
@@ -2515,10 +2523,6 @@ es6-iterator@^2.0.1, es6-iterator@~2.0.1:
     d "1"
     es5-ext "^0.10.35"
     es6-symbol "^3.1.1"
-
-es6-promise@^4.1.1:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.2.tgz#f722d7769af88bd33bc13ec6605e1f92966b82d9"
 
 es6-symbol@^3.1.1, es6-symbol@~3.1.1:
   version "3.1.1"
@@ -6624,6 +6628,10 @@ redux@^3.7.2:
 regenerate@^1.2.1:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.3.3.tgz#0c336d3980553d755c39b586ae3b20aa49c82b7f"
+
+regenerator-runtime@^0.10.5:
+  version "0.10.5"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
 regenerator-runtime@^0.11.0:
   version "0.11.1"


### PR DESCRIPTION
cc @danielfdsilva this swaps out the es6-promise polyfill for babel-polyfill, which includes support for `object.assign` in old Safari.