### PR TITLE
Use leading slash before assets

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -13,7 +13,7 @@
     <meta name="twitter:site" content="" />
     <meta name="twitter:title" content="">
     <meta name="twitter:description" content="" />
-    <meta name="twitter:image:src" content="assets/graphics/meta/default-meta-image.png" />
+    <meta name="twitter:image:src" content="/assets/graphics/meta/default-meta-image.png" />
     <!--/ Twitter -->
 
     <!-- OG -->
@@ -22,18 +22,18 @@
     <meta property="og:url" content="" />
     <meta property="og:type" content="website" />
     <meta property="og:description" content="" />
-    <meta property="og:image" content="assets/graphics/meta/default-meta-image.png" />
+    <meta property="og:image" content="/assets/graphics/meta/default-meta-image.png" />
     <!--/ OG -->
 
-    <link rel="shortcut icon" href="assets/graphics/meta/favicon.ico" type="image/x-icon" />
-    <link rel="apple-touch-icon" href="assets/graphics/meta/apple-touch-icon.png" />
-    <link rel="apple-touch-icon" sizes="57x57" href="assets/graphics/meta/apple-touch-icon-57x57.png" />
-    <link rel="apple-touch-icon" sizes="72x72" href="assets/graphics/meta/apple-touch-icon-72x72.png" />
-    <link rel="apple-touch-icon" sizes="76x76" href="assets/graphics/meta/apple-touch-icon-76x76.png" />
-    <link rel="apple-touch-icon" sizes="114x114" href="assets/graphics/meta/apple-touch-icon-114x114.png" />
-    <link rel="apple-touch-icon" sizes="120x120" href="assets/graphics/meta/apple-touch-icon-120x120.png" />
-    <link rel="apple-touch-icon" sizes="144x144" href="assets/graphics/meta/apple-touch-icon-144x144.png" />
-    <link rel="apple-touch-icon" sizes="152x152" href="assets/graphics/meta/apple-touch-icon-152x152.png" />
+    <link rel="shortcut icon" href="/assets/graphics/meta/favicon.ico" type="image/x-icon" />
+    <link rel="apple-touch-icon" href="/assets/graphics/meta/apple-touch-icon.png" />
+    <link rel="apple-touch-icon" sizes="57x57" href="/assets/graphics/meta/apple-touch-icon-57x57.png" />
+    <link rel="apple-touch-icon" sizes="72x72" href="/assets/graphics/meta/apple-touch-icon-72x72.png" />
+    <link rel="apple-touch-icon" sizes="76x76" href="/assets/graphics/meta/apple-touch-icon-76x76.png" />
+    <link rel="apple-touch-icon" sizes="114x114" href="/assets/graphics/meta/apple-touch-icon-114x114.png" />
+    <link rel="apple-touch-icon" sizes="120x120" href="/assets/graphics/meta/apple-touch-icon-120x120.png" />
+    <link rel="apple-touch-icon" sizes="144x144" href="/assets/graphics/meta/apple-touch-icon-144x144.png" />
+    <link rel="apple-touch-icon" sizes="152x152" href="/assets/graphics/meta/apple-touch-icon-152x152.png" />
 
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Poppins:500|Roboto:300italic,400italic,700italic,400,300,700" type="text/css" />
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -245,7 +245,15 @@ gulp.task('styles', function () {
 
 gulp.task('html', ['styles'], function () {
   return gulp.src('app/*.html')
-    .pipe($.useref({searchPath: ['.tmp', 'app', '.']}))
+    .pipe($.useref({
+      searchPath: ['.tmp', 'app', '.'],
+      transformTargetPath: function (filePath, type) {
+        if (type === 'css' || type === 'js') {
+          return '/' + filePath;
+        }
+        return filePath;
+      }
+    }))
     // Do not compress comparisons, to avoid MapboxGLJS minification issue
     // https://github.com/mapbox/mapbox-gl-js/issues/4359#issuecomment-286277540
     .pipe($.if('*.js', $.uglify({compress: {comparisons: false}})))


### PR DESCRIPTION
This is because on pages like `/emergencies/7` the proxy causes the assets route to translate as `/emergencies/assets/...` which is wrong. This should address that.