### PR TITLE
Fix disaster types to match api

### DIFF
--- a/app/assets/scripts/utils/field-report-constants.js
+++ b/app/assets/scripts/utils/field-report-constants.js
@@ -1123,7 +1123,7 @@ export const disasterType = [
   },
   {
     value: '12',
-    label: 'Food'
+    label: 'Flood'
   },
   {
     value: '21',
@@ -1140,10 +1140,6 @@ export const disasterType = [
   {
     value: '24',
     label: 'Landslide'
-  },
-  {
-    value: '29',
-    label: 'Local storm'
   },
   {
     value: '13',


### PR DESCRIPTION
Close #217 

Remove the local storm disaster type.
Fix spelling of "Flood".