### PR TITLE
Numeric addition of floats to have percentage

### DIFF
--- a/app/assets/scripts/components/connected/featured-emergencies.js
+++ b/app/assets/scripts/components/connected/featured-emergencies.js
@@ -24,8 +24,8 @@ class FeaturedEmergencies extends React.Component {
     // get appeals data
     const appeals = get(d, 'appeals', []);
     const beneficiaries = appeals.reduce((acc, curr) => acc + curr.num_beneficiaries, 0);
-    const requested = appeals.reduce((acc, curr) => acc + curr.amount_requested, 0);
-    const funded = appeals.reduce((acc, curr) => acc + curr.amount_funded, 0);
+    const requested = appeals.reduce((acc, curr) => acc + Number(curr.amount_requested), 0);
+    const funded = appeals.reduce((acc, curr) => acc + Number(curr.amount_funded), 0);
 
     // get field report data, in case appeals data is missing
     const report = mostRecentReport(get(d, 'field_reports'));


### PR DESCRIPTION
There were two decimal numbers in funded/requested, and the addition made them a strange creature (0398154.91253671.00 and 05425000.00253671.00), which had two+two decimal points, so could not be treated as numbers and can not be divised with each other.