### PR TITLE
Using dtype as a structure instead of number

### DIFF
--- a/app/assets/scripts/utils/utils.js
+++ b/app/assets/scripts/utils/utils.js
@@ -135,7 +135,7 @@ export function getCountryIsoFromVt (feature) {
 }
 
 export function groupByDisasterType (objs) {
-  const emergenciesByType = _groupBy(objs, 'dtype');
+  const emergenciesByType = _groupBy(objs, 'dtype.id');
   return Object.keys(emergenciesByType).map(key => {
     let meta = getDtypeMeta(key);
     if (!meta) return null;


### PR DESCRIPTION
In the old version (as somehow my local debug environment used) in /api/v2/event/ the dtype was a number. In the new version (due to verbose CSV) the dtype is a structure, like

 ```
"dtype": {
                "name": "Other",
                "summary": "",
                "id": 13
            },
```