### PR TITLE
Appeals, emergencies and field-reports table dtype display fix

### DIFF
--- a/app/assets/scripts/components/connected/appeals-table.js
+++ b/app/assets/scripts/components/connected/appeals-table.js
@@ -183,7 +183,7 @@ class AppealsTable extends SFPComponent {
         code: o.code,
         name: o.name,
         event: o.event ? <Link to={`/emergencies/${o.event}`} className='link--primary' title='View Emergency'>Link</Link> : nope,
-        dtype: get(getDtypeMeta(o.dtype), 'label', nope),
+        dtype: get(getDtypeMeta(o.dtype.id), 'label', nope),
         requestAmount: {
           value: n(o.amount_requested),
           className: 'right-align'

--- a/app/assets/scripts/components/connected/emergencies-table.js
+++ b/app/assets/scripts/components/connected/emergencies-table.js
@@ -169,7 +169,7 @@ class EmergenciesTable extends SFPComponent {
           id: rowData.id,
           date: date,
           name: <Link className='link--primary' to={`/emergencies/${rowData.id}`}>{get(rowData, 'name', nope)}</Link>,
-          dtype: rowData.dtype ? rowData.dtype : nope,
+          dtype: rowData.dtype ? rowData.dtype.name : nope,
           requested: {
             value: n(get(rowData, 'appeals.0.amount_requested')),
             className: 'right-align'

--- a/app/assets/scripts/components/connected/field-reports-table.js
+++ b/app/assets/scripts/components/connected/field-reports-table.js
@@ -146,7 +146,7 @@ class FieldReportsTable extends SFPComponent {
         date: DateTime.fromISO(o.created_at).toISODate(),
         name: <Link to={`/reports/${o.id}`} className='link--primary' title='View Field Report'>{o.summary || nope}</Link>,
         event: o.event ? <Link to={`/emergencies/${o.event.id}`} className='link--primary' title='View Emergency'>{o.event.name}</Link> : nope,
-        dtype: get(getDtypeMeta(o.dtype), 'label', nope),
+        dtype: get(getDtypeMeta(o.dtype.id), 'label', nope),
         countries: intersperse(o.countries.map(c => <Link key={c.id} to={`/countries/${c.id}`} className='link--primary' title='View Country'>{c.name}</Link>), ', ')
       }));
 

--- a/app/assets/scripts/views/field-report.js
+++ b/app/assets/scripts/views/field-report.js
@@ -171,9 +171,9 @@ class FieldReport extends React.Component {
                     <dt>Displaced (RC): </dt>
                     <dd>{n(get(data, 'num_displaced'))}</dd>
                     <dt>Affected (RC): </dt>
-                    <dd>{n(get(data, 'num_displaced'))}</dd>
+                    <dd>{n(get(data, 'num_affected'))}</dd>
                     <dt>Assisted (RC): </dt>
-                    <dd>{n(get(data, 'num_displaced'))}</dd>
+                    <dd>{n(get(data, 'num_assisted'))}</dd>
                   </dl>
                   <dl className='dl-horizontal numeric-list'>
                     <dt>Injured (Government): </dt>
@@ -187,7 +187,7 @@ class FieldReport extends React.Component {
                     <dt>Affected (Government): </dt>
                     <dd>{n(get(data, 'gov_num_affected'))}</dd>
                     <dt>Assisted (Government): </dt>
-                    <dd>{n(get(data, 'gov_num_displaced'))}</dd>
+                    <dd>{n(get(data, 'gov_num_assisted'))}</dd>
                   </dl>
                   <dl className='dl-horizontal numeric-list'>
                     <dt>Local Staff: </dt>


### PR DESCRIPTION
The changing of dtype representation in rich CSV export caused to be changed the displayed tables structure also.