### PR TITLE
Select areas while entering Field Report details

### DIFF
--- a/app/assets/scripts/actions/index.js
+++ b/app/assets/scripts/actions/index.js
@@ -207,6 +207,16 @@ export function getEruOwners () {
   return fetchJSON('api/v2/eru_owner/?limit=0', GET_ERU_OWNERS, withToken());
 }
 
+export const GET_DISTRICTS = 'GET_DISTRICTS';
+export function getDistrictsForCountry (country) {
+  const filters = {
+    country: country.value,
+    limit: 200
+  };
+  const f = buildAPIQS(filters);
+  return fetchJSON(`api/v2/district/?${f}`, GET_DISTRICTS, {}, { country });
+}
+
 export const GET_AA = 'GET_AA';
 export function getAdmAreaById (aaType, id) {
   switch (aaType) {

--- a/app/assets/scripts/reducers/districts.js
+++ b/app/assets/scripts/reducers/districts.js
@@ -1,0 +1,31 @@
+'use strict';
+
+import { stateInflight, stateError, stateSuccess } from '../utils/reducer-utils';
+
+const initialState = {};
+
+export default function districts (state = initialState, action) {
+  let countryId;
+  if (action.type.startsWith('GET_DISTRICTS_')) {
+    state = Object.assign({}, state);
+    countryId = action.country.value;
+    state[countryId] = state[countryId] || {
+      fetching: false,
+      fetched: false,
+      receivedAt: null,
+      data: {}
+    };
+  }
+  switch (action.type) {
+    case 'GET_DISTRICTS_INFLIGHT':
+      state[countryId] = stateInflight(state[countryId], action);
+      break;
+    case 'GET_DISTRICTS_FAILED':
+      state[countryId] = stateError(state[countryId], action);
+      break;
+    case 'GET_DISTRICTS_SUCCESS':
+      state[countryId] = stateSuccess(state[countryId], action);
+      break;
+  }
+  return state;
+}

--- a/app/assets/scripts/reducers/index.js
+++ b/app/assets/scripts/reducers/index.js
@@ -5,6 +5,7 @@ import { systemAlertsReducer } from '../components/system-alerts';
 import user from './user';
 import profile from './profile';
 import countries from './countries';
+import districts from './districts';
 import fieldReportForm from './field-report-form';
 import fieldReport from './field-report';
 import fieldReports from './field-reports';
@@ -31,6 +32,7 @@ export const reducers = {
   user,
   profile,
   countries,
+  districts,
   systemAlertsReducer,
   fieldReportForm,
   fieldReport,

--- a/app/assets/scripts/schemas/field-report-form.js
+++ b/app/assets/scripts/schemas/field-report-form.js
@@ -19,6 +19,9 @@ export const step1 = {
       type: 'string',
       enum: getValidValues(formData.countries, 'value')
     },
+    districts: {
+      type: 'array'
+    },
     status: {
       type: 'string',
       enum: getValidValues(formData.status, 'value')

--- a/app/assets/scripts/schemas/field-report-form.js
+++ b/app/assets/scripts/schemas/field-report-form.js
@@ -8,12 +8,16 @@ export const step1 = {
     summary: {
       type: 'string'
     },
-    countries: {
-      type: 'array',
-      minItems: 1,
-      items: {
-        enum: getValidValues(formData.countries, 'value')
-      }
+    // countries: {
+    //   type: 'array',
+    //   minItems: 1,
+    //   items: {
+    //     enum: getValidValues(formData.countries, 'value')
+    //   }
+    // },
+    country: {
+      type: 'string',
+      enum: getValidValues(formData.countries, 'value')
     },
     status: {
       type: 'string',
@@ -34,7 +38,7 @@ export const step1 = {
       type: 'boolean'
     }
   },
-  required: ['summary', 'countries', 'status', 'disasterType']
+  required: ['summary', 'country', 'status', 'disasterType']
 };
 
 export const step2 = {

--- a/app/assets/scripts/views/field-report-form/data-utils.js
+++ b/app/assets/scripts/views/field-report-form/data-utils.js
@@ -17,6 +17,7 @@ export function dataPathToDisplay (path) {
     summary: 'Summary',
     country: 'Country',
     countries: 'Countries',
+    districts: 'Areas',
     status: 'Status',
     disasterType: 'Disaster Type',
     event: 'Event',
@@ -90,6 +91,7 @@ export function prepStateForValidation (state) {
     // Step 1.
     assistance: toBool,
     country: (val) => val.value,
+    districts: (val) => val.map(o => o.value),
     // countries: (val) => val.value,
     event: (val) => val ? toNumIfNum(val.value) : undefined,
 
@@ -127,17 +129,18 @@ export function convertStateToPayload (originalState) {
   // Prepare the payload for submission.
   // Extract properties that need processing.
   originalState = _cloneDeep(originalState);
-  console.log('original state', originalState);
   let state = {};
   const {
     country,
     disasterType,
+    districts,
     event
   } = originalState;
 
   // Process properties.
   // if (countries.length) { state.countries = countries.map(o => +o.value); }
   if (disasterType) { state.dtype = +disasterType; }
+  if (districts.length) { state.districts = districts.map(o => +o.value); }
   if (event && event.value) { state.event = +event.value; }
   if (country) { state.countries = [country.value]; }
 
@@ -293,6 +296,7 @@ export function getInitialDataState () {
     // Will need to be converted.
     country: undefined,
     // countries: [],
+    districts: [],
     status: undefined,
     visibility: '1',
     disasterType: undefined,
@@ -370,6 +374,10 @@ export function convertFieldReportToState (fieldReport) {
   }));
   state.country = fieldReport.countries.length ? state.countries[0] : null;
 
+  state.districts = fieldReport.districts.map(o => ({
+    label: o.name,
+    value: o.id.toString()
+  }));
   // delete state.countries;
 
   if (fieldReport.dtype) {

--- a/app/assets/scripts/views/field-report-form/data-utils.js
+++ b/app/assets/scripts/views/field-report-form/data-utils.js
@@ -15,6 +15,7 @@ export function dataPathToDisplay (path) {
   const index = {
     // Step 1.
     summary: 'Summary',
+    country: 'Country',
     countries: 'Countries',
     status: 'Status',
     disasterType: 'Disaster Type',
@@ -88,7 +89,8 @@ export function prepStateForValidation (state) {
   const formatter = {
     // Step 1.
     assistance: toBool,
-    countries: (val) => val.map(o => o.value),
+    country: (val) => val.value,
+    // countries: (val) => val.value,
     event: (val) => val ? toNumIfNum(val.value) : undefined,
 
     // Step 2.
@@ -125,17 +127,19 @@ export function convertStateToPayload (originalState) {
   // Prepare the payload for submission.
   // Extract properties that need processing.
   originalState = _cloneDeep(originalState);
+  console.log('original state', originalState);
   let state = {};
   const {
-    countries,
+    country,
     disasterType,
     event
   } = originalState;
 
   // Process properties.
-  if (countries.length) { state.countries = countries.map(o => +o.value); }
+  // if (countries.length) { state.countries = countries.map(o => +o.value); }
   if (disasterType) { state.dtype = +disasterType; }
   if (event && event.value) { state.event = +event.value; }
+  if (country) { state.countries = [country.value]; }
 
   const directMapping = [
     // [source, destination]
@@ -287,7 +291,8 @@ export function getInitialDataState () {
     summary: undefined,
     // Countries follows the structure defined by react-select.
     // Will need to be converted.
-    countries: [],
+    country: undefined,
+    // countries: [],
     status: undefined,
     visibility: '1',
     disasterType: undefined,
@@ -363,6 +368,10 @@ export function convertFieldReportToState (fieldReport) {
     label: o.name,
     value: o.id.toString()
   }));
+  state.country = fieldReport.countries.length ? state.countries[0] : null;
+
+  // delete state.countries;
+
   if (fieldReport.dtype) {
     state.disasterType = fieldReport.dtype.id.toString();
   }

--- a/app/assets/scripts/views/field-report-form/index.js
+++ b/app/assets/scripts/views/field-report-form/index.js
@@ -292,8 +292,8 @@ class FieldReportForm extends React.Component {
         </div>
 
         <div className='form__group'>
-          <label className='form__label'>Areas</label>
-          <p className='form__description'>Search for areas within affected country.</p>
+          <label className='form__label'>Regions / Provinces</label>
+          <p className='form__description'>Search for regions within affected country.</p>
           <Select
             name='districts'
             value={this.state.data.districts}

--- a/app/assets/scripts/views/field-report-form/index.js
+++ b/app/assets/scripts/views/field-report-form/index.js
@@ -246,18 +246,18 @@ class FieldReportForm extends React.Component {
         </FormInput>
 
         <div className='form__group'>
-          <label className='form__label'>Countries *</label>
-          <p className='form__description'>Seach for the affected country. You can select more than one.</p>
+          <label className='form__label'>Country *</label>
+          <p className='form__description'>Seach for the affected country.</p>
           <Select
-            name='countries'
-            value={this.state.data.countries}
-            onChange={this.onFieldChange.bind(this, 'countries')}
+            name='country'
+            value={this.state.data.country}
+            onChange={this.onFieldChange.bind(this, 'country')}
             options={formData.countries}
-            multi />
+          />
 
           <FormError
             errors={this.state.errors}
-            property='countries'
+            property='country'
           />
         </div>
 

--- a/app/assets/scripts/views/field-report-form/index.js
+++ b/app/assets/scripts/views/field-report-form/index.js
@@ -96,6 +96,8 @@ class FieldReportForm extends React.Component {
       if (!nextProps.report.error) {
         const prefillState = convertFieldReportToState(nextProps.report.data);
         this.setState({data: prefillState});
+        const country = prefillState.country;
+        if (country) this.updateDistricts(country);
       }
     }
   }

--- a/app/assets/scripts/views/field-report-form/index.js
+++ b/app/assets/scripts/views/field-report-form/index.js
@@ -20,7 +20,7 @@ import {
 } from '../../schemas/field-report-form';
 import * as formData from '../../utils/field-report-constants';
 import { showAlert } from '../../components/system-alerts';
-import { createFieldReport, updateFieldReport, getFieldReportById } from '../../actions';
+import { createFieldReport, updateFieldReport, getFieldReportById, getDistrictsForCountry } from '../../actions';
 import { showGlobalLoading, hideGlobalLoading } from '../../components/global-loading';
 import {
   dataPathToDisplay,
@@ -175,6 +175,33 @@ class FieldReportForm extends React.Component {
     }
   }
 
+  updateDistricts (e) {
+    this.props._getDistrictsForCountry(e);
+    return true;
+  }
+
+  getDistrictChoices () {
+    const { districts } = this.props;
+    const country = this.state.data.country;
+    if (!country) return [];
+    const countryId = country.value;
+    if (districts.hasOwnProperty(countryId) && districts[countryId].fetched) {
+      return districts[countryId].data.results.map(d => {
+        return {
+          'value': d.id,
+          'label': d.name
+        };
+      });
+    } else {
+      return [];
+    }
+  }
+
+  onCountryChange (e) {
+    this.updateDistricts(e);
+    this.onFieldChange('country', e);
+  }
+
   onFieldChange (field, e) {
     let data = _cloneDeep(this.state.data);
     let val = e && e.target ? e.target.value : e;
@@ -224,6 +251,7 @@ class FieldReportForm extends React.Component {
   }
 
   renderStep1 () {
+    const districtChoices = this.getDistrictChoices() || [];
     return (
       <Fold title='Basic Information'>
         <FormInput
@@ -251,7 +279,7 @@ class FieldReportForm extends React.Component {
           <Select
             name='country'
             value={this.state.data.country}
-            onChange={this.onFieldChange.bind(this, 'country')}
+            onChange={this.onCountryChange.bind(this)}
             options={formData.countries}
           />
 
@@ -261,6 +289,22 @@ class FieldReportForm extends React.Component {
           />
         </div>
 
+        <div className='form__group'>
+          <label className='form__label'>Areas</label>
+          <p className='form__description'>Search for areas within affected country.</p>
+          <Select
+            name='districts'
+            value={this.state.data.districts}
+            onChange={this.onFieldChange.bind(this, 'districts')}
+            options={districtChoices}
+            multi
+          />
+
+          <FormError
+            errors={this.state.errors}
+            property='districts'
+          />
+        </div>
         <FormRadioGroup
           label='Status *'
           name='status'
@@ -767,6 +811,8 @@ if (environment !== 'production') {
     _createFieldReport: T.func,
     _updateFieldReport: T.func,
     _getFieldReportById: T.func,
+    _getDistrictsForCountry: T.func,
+    districts: T.object,
     fieldReportForm: T.object,
     user: T.object,
     report: T.object,
@@ -785,13 +831,15 @@ const selector = (state, ownProps) => ({
     data: {},
     fetching: false,
     fetched: false
-  })
+  }),
+  districts: state.districts
 });
 
 const dispatcher = (dispatch) => ({
   _createFieldReport: (...args) => dispatch(createFieldReport(...args)),
   _updateFieldReport: (...args) => dispatch(updateFieldReport(...args)),
-  _getFieldReportById: (...args) => dispatch(getFieldReportById(...args))
+  _getFieldReportById: (...args) => dispatch(getFieldReportById(...args)),
+  _getDistrictsForCountry: (...args) => dispatch(getDistrictsForCountry(...args))
 });
 
 export default connect(selector, dispatcher)(FieldReportForm);


### PR DESCRIPTION
Have made changes to the Field Report form as per https://github.com/IFRCGo/go-frontend/issues/642:

 - Allow a user to only select a single Country
 - When user selects Country, populate `Areas` dropdown with `Areas` of that country
 - Allow user to select multiple `Areas` and save
 - Handle loading of `Areas` correctly.

The form seems to work fine to add as well as edit, but it would be nice to test a bit more.

We may want to consider adding some information about the `Areas`  in the Field Report summary. To discuss.

It would probably be good to get this on `stage` soon, though it requires this backend PR to be merged first: https://github.com/IFRCGo/go-api/pull/457

@mankamolnar will be great if you can have a quick look - if it seems okay to you, we can chat on the call tomorrow and figure out next steps to merge and test. Thank you!

Note: When I use the word `Areas` above, it is the same as `Districts` / `Admin1` boundaries. @ElsaRaunioIFRC suggested to use the word `Areas` on the frontend, so that is how it is displayed on the frontend on this form.