### PR TITLE
changes map expand btn text

### DIFF
--- a/app/assets/scripts/components/map/home-map.js
+++ b/app/assets/scripts/components/map/home-map.js
@@ -288,7 +288,7 @@ class HomeMap extends React.Component {
             <button className='button button--secondary-bounded button--small button--fullscreen'
               onClick={this.props.toggleFullscreen}
               title='View in fullscreen'>
-              <span>{this.props.fullscreen ? 'Close the Map' : 'Expand the map'}</span>
+              <span>{this.props.fullscreen ? 'Close the Map' : 'Presentation Mode'}</span>
             </button>
           </div>
         </div>


### PR DESCRIPTION
#765 This updates the text on the home page map to say 'presentation mode' instead of 'expand map'