### PR TITLE
hide language selection drop-down on PER forms, fixes #808

### DIFF
--- a/app/assets/scripts/components/per-forms/per-form-component.js
+++ b/app/assets/scripts/components/per-forms/per-form-component.js
@@ -8,6 +8,13 @@ import RequestFactory from './factory/request-factory';
 const requestFactory = new RequestFactory();
 
 const renderLanguageSelectDropdown = (props) => {
+  /*
+  The language selection code is commented out as per
+  https://github.com/IFRCGo/go-frontend/issues/808
+
+  Intentionally leaving this commented out because we will want to
+  bring this functionality back.
+
   return (<div>
     <span style={{fontWeight: 'bold'}}>Form language:</span>&nbsp;
 
@@ -17,6 +24,10 @@ const renderLanguageSelectDropdown = (props) => {
       <option value='french'>French</option>
     </select><br /><br />
   </div>);
+  */
+
+  // Render null for now, see above.
+  return null;
 };
 
 if (environment !== 'production') {


### PR DESCRIPTION
I'm having a bit of a hard time figuring out testing this, see https://github.com/IFRCGo/go-frontend/issues/808#issuecomment-529891501

But, from what I can tell, this *should* work.

@necoline can I ask you to give this a quick look and let me know if this seems sane? We want to (temporarily) hide the language selector on these forms as per #808 .

I will ask the team to test thoroughly once we merge this to develop to check that this does indeed work.