### PR TITLE
fix personnel not showing on emergency page even when there are personnel

### DIFF
--- a/app/assets/scripts/views/emergency.js
+++ b/app/assets/scripts/views/emergency.js
@@ -517,7 +517,7 @@ class Emergency extends React.Component {
                     emergency={this.props.match.params.id}
                   />
                 </TabContent>
-                <TabContent isError={!get(this.props.personnel, 'data.results.length')} errorMessage={ NO_DATA } title="Personnel">
+                <TabContent title="Personnel">
                   <PersonnelTable id='personnel'
                     emergency={this.props.match.params.id}
                   />


### PR DESCRIPTION
We can't depend on the length of this.props.personnel, because we just send the ID of the Emergency to the PersonnelTable that then fetches data from the API.

So, remove the error condition for this TabContent, and let the Personnel Table handle whether it needs to be displayed or not based on data.