### PR TITLE
Fix/828 remove presentation filters

### DIFF
--- a/app/assets/scripts/components/map/main-map.js
+++ b/app/assets/scripts/components/map/main-map.js
@@ -274,23 +274,26 @@ class MainMap extends React.Component {
             onDtypeHover={this.onDtypeHover.bind(this)}/>}
 
         <div className={mapContainerClassName}>
-          <div className='map-vis__legend__filters'>
-            <div className='map-vis__legend__filters-wrap'>
-              <DateFilterHeader
-                id='date'
-                title='Date'
-                filter={this.state.filters}
-                featureType='map'
-                onSelect={this.handleDateChange.bind(this)} />
+          {!this.props.fullscreen ? (
+            <div className='map-vis__legend__filters'>
+              <div className='map-vis__legend__filters-wrap'>
+                <DateFilterHeader
+                  id='date'
+                  title='Date'
+                  filter={this.state.filters}
+                  featureType='map'
+                  onSelect={this.handleDateChange.bind(this)} />
+              </div>
+              <div className='map-vis__legend__filters-wrap'>
+                <EmergencyTypesDropdown emergenciesByType={emergenciesByType}
+                  onDtypeClick={this.onDtypeClick.bind(this)} />
+              </div>
+              <div className='map-vis__legend__filters-wrap'>
+                <AppealTypesDropdown onAppealTypeChange={this.onAppealTypeChange.bind(this)} />
+              </div>
             </div>
-            <div className='map-vis__legend__filters-wrap'>
-              <EmergencyTypesDropdown emergenciesByType={emergenciesByType}
-                onDtypeClick={this.onDtypeClick.bind(this)} />
-            </div>
-            <div className='map-vis__legend__filters-wrap'>
-              <AppealTypesDropdown onAppealTypeChange={this.onAppealTypeChange.bind(this)} />
-            </div>
-          </div>
+          ) : null
+          }
           <MapComponent className='map-vis__holder'
             noExport={this.props.noExport}
             configureMap={this.configureMap}

--- a/app/assets/styles/home/_presenting.scss
+++ b/app/assets/styles/home/_presenting.scss
@@ -3,7 +3,7 @@
   height: 100vh;
   .inner {
     max-width: 1600px;
-    margin-top: $global-spacing/2;
+    margin-top: $global-spacing * 2;
   }
 
   .fold__header {

--- a/app/assets/styles/home/_presenting.scss
+++ b/app/assets/styles/home/_presenting.scss
@@ -3,6 +3,7 @@
   height: 100vh;
   .inner {
     max-width: 1600px;
+    margin-top: $global-spacing/2;
   }
 
   .fold__header {
@@ -22,7 +23,7 @@
   }
 
   .appeals--fullscreen {
-    margin-top: 80px;
+    margin-top: $global-spacing * 2;
   }
 
   .stats-map .emergencies .emergencies__item {
@@ -89,7 +90,7 @@
 }
 
 .inpage__title--map-fullscreen {
-  padding-left: 430px; // width of logo + some padding
+  padding-left: 400px; // width of logo + some padding
   margin: ($global-spacing/2) 0 0 0;
   text-align: left;
   font-size: 2rem;


### PR DESCRIPTION
## Description
Removes map filters from presentation mode on:
- [x] home page 
- [x] region page

## Related Issue
#828 

## Motivation and Context
There is no need to edit the map in presentation mode. The purpose of this feature is to display the map with the setting determined on the page.


## Screenshots (if appropriate):
Home Page:
![image](https://user-images.githubusercontent.com/20410256/68247527-05b93f00-ffe9-11e9-9ff2-f6428c30c178.png)

Region Page:
![image](https://user-images.githubusercontent.com/20410256/68247416-cdb1fc00-ffe8-11e9-8704-75b771ca9d58.png)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
