### PR TITLE
Fix/846 highlighted ops

### DIFF
--- a/app/assets/scripts/components/highlighted-operations/index.js
+++ b/app/assets/scripts/components/highlighted-operations/index.js
@@ -77,7 +77,7 @@ class HighlightedOperations extends React.Component {
       <div className='inner inner--emergencies'>
         <Fold title={title} navLink={foldLink} extraClass foldClass='fold__title--inline'>
           <ul className='key-emergencies-list'>
-            {data.results.map(operation =>
+            {data.results.slice(0, 3).map(operation =>
               <OperationCard
                 operation={operation}
                 calculateDeployedPersonnel={this.calculateDeployedPersonnel}

--- a/app/assets/scripts/components/highlighted-operations/index.js
+++ b/app/assets/scripts/components/highlighted-operations/index.js
@@ -4,6 +4,7 @@ import { PropTypes as T } from 'prop-types';
 import { Link } from 'react-router-dom';
 import { environment } from '../../config';
 import { getFeaturedEmergencies, getFeaturedEmergenciesDeployments, getDeploymentERU } from '../../actions';
+import { countriesByRegion } from '../../utils/region-constants';
 import BlockLoading from '../block-loading';
 import Fold from '../fold';
 import OperationCard from './operation-card';
@@ -73,11 +74,19 @@ class HighlightedOperations extends React.Component {
     const foldLink = (<Link to='/appeals/all' className='fold__title__link'>View all operations</Link>);
     if (fetched && (error || !Array.isArray(data.results) || !data.results.length)) return null;
     else if (!fetched || fetching) return <div className='inner'><Fold title={title}><BlockLoading/></Fold></div>;
-    return (
+    let operations = data.results;
+    if (this.props.opsType === 'region') {
+      operations = operations.filter(op => countriesByRegion[this.props.opsId].includes(op.countries[0].id.toString()));
+    }
+    if (this.props.opsType === 'country') {
+      operations = operations.filter(op => op.countries[0].id === this.props.opsId);
+    }
+    return (operations.length ? (
       <div className='inner inner--emergencies'>
         <Fold title={title} navLink={foldLink} extraClass foldClass='fold__title--inline'>
           <ul className='key-emergencies-list'>
-            {data.results.slice(0, 3).map(operation =>
+            {/* displays the first three operations sorted by most recent by default */}
+            {operations.slice(0, 3).map(operation =>
               <OperationCard
                 operation={operation}
                 calculateDeployedPersonnel={this.calculateDeployedPersonnel}
@@ -86,6 +95,7 @@ class HighlightedOperations extends React.Component {
           </ul>
         </Fold>
       </div>
+    ) : null
     );
   }
 }
@@ -97,7 +107,9 @@ if (environment !== 'production') {
     _getDeploymentERU: T.func,
     featured: T.object,
     deployments: T.object,
-    eru: T.object
+    eru: T.object,
+    opsType: T.string,
+    opsId: T.string,
   };
 }
 

--- a/app/assets/scripts/components/highlighted-operations/operation-card.js
+++ b/app/assets/scripts/components/highlighted-operations/operation-card.js
@@ -48,19 +48,12 @@ const OperationCard = ({operation, calculateDeployedPersonnel}) => {
         </div>
 
         <div className='card_box_full card_box_container card_box_container--op'>
-          <div className='card_box card_box_left card_box--op'>
-            <div className="heading-tiny">Funding Coverage</div>
-          </div>
-
-          <div className='card_box card_box_left card_box--op'>
-            <div className="card_box_fc">{requested ? round(percent(funded, requested)) : 0}%</div>
-          </div>
+          <div className="heading-tiny">Funding Coverage</div>
+          <div className="card_box_fc">{requested ? round(percent(funded, requested)) : 0}%</div>
         </div>
-        {appeals.length ? (
-          <React.Fragment>
-            <Progress value={requested ? percent(funded, requested) : 0} max={100} />
-          </React.Fragment>
-        ) : null}
+        <div className="card_box_footer">
+          <Progress value={requested ? percent(funded, requested) : percent(0.1, 10)} max={100} />
+        </div>
       </Link>
     </li>
   );

--- a/app/assets/scripts/components/highlighted-operations/operation-card.js
+++ b/app/assets/scripts/components/highlighted-operations/operation-card.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import { get } from '../../utils/utils';
+import { Link } from 'react-router-dom';
+import { environment } from '../../config';
+import { PropTypes } from 'prop-types';
+import { formatDate, percent, round, commaSeparatedNumber as n } from '../../utils/format';
+import Progress from './../progress-labeled';
+
+const OperationCard = ({operation, calculateDeployedPersonnel}) => {
+  const { id, name } = operation;
+  const appeals = get(operation, 'appeals', []);
+  const beneficiaries = appeals.reduce((acc, curr) => acc + curr.num_beneficiaries, 0);
+  const requested = appeals.reduce((acc, curr) => acc + Number(curr.amount_requested), 0);
+  const funded = appeals.reduce((acc, curr) => acc + Number(curr.amount_funded), 0);
+  const emergencyDeployments = calculateDeployedPersonnel(operation);
+
+  return (
+    <li className='key-emergencies-item' key={id}>
+      <Link to={`/emergencies/${id}`}>
+        <div className="card_box card_box_left">
+          <h2 className='card__title'>{ name.length > 30 ? name.slice(0, 30) + '...' : name }</h2>
+          <small className='last_updated'>Last updated: {formatDate(operation.updated_at)}</small>
+        </div>
+
+        <div className='card_box_container card_box_container--op'>
+          <div className='card_box card_box_left card_box--op'>
+            <div className="card_box_no">{n(beneficiaries)}</div>
+            <span className='affected_population_icon'></span>
+            <small className='heading-tiny'>Targeted Population</small>
+          </div>
+          <div className='card_box card_box_left card_box--op'>
+            <span className='affected_population_icon'></span>
+            <div className="card_box_no">{n(emergencyDeployments.deployedErus)}</div>
+            <small className='heading-tiny'>Deployed Emergency Response Units</small>
+          </div>
+        </div>
+
+        <div className='card_box_container card_box_container--op'>
+          <div className='card_box card_box_left card_box--op'>
+            <div className="card_box_no">{requested !== null ? n(requested) : 0} CHF</div>
+            <small className='heading-tiny'>Funding Requirements</small>
+          </div>
+          <div className='card_box card_box_left card_box--op'>
+            <span className='deployed_personnel_icon'></span>
+            <div className="card_box_no">{n(emergencyDeployments.deployedPersonnel)}</div>
+            <small className='heading-tiny'>Deployed Surge Personnel</small>
+          </div>
+        </div>
+
+        <div className='card_box_full card_box_container card_box_container--op'>
+          <div className='card_box card_box_left card_box--op'>
+            <div className="heading-tiny">Funding Coverage</div>
+          </div>
+
+          <div className='card_box card_box_left card_box--op'>
+            <div className="card_box_fc">{requested ? round(percent(funded, requested)) : 0}%</div>
+          </div>
+        </div>
+        {appeals.length ? (
+          <React.Fragment>
+            <Progress value={requested ? percent(funded, requested) : 0} max={100} />
+          </React.Fragment>
+        ) : null}
+      </Link>
+    </li>
+  );
+};
+
+export default OperationCard;
+
+if (environment !== 'production') {
+  OperationCard.propTypes = {
+    operation: PropTypes.object,
+    calculateDeployedPersonnel: PropTypes.func
+  };
+}

--- a/app/assets/scripts/views/countries.js
+++ b/app/assets/scripts/views/countries.js
@@ -43,6 +43,7 @@ import TabContent from '../components/tab-content';
 import Fold from '../components/fold';
 import DisplayTable, { SortHeader, FilterHeader } from '../components/display-table';
 import EmergenciesTable from '../components/connected/emergencies-table';
+import HighlightedOperations from '../components/highlighted-operations';
 // import BulletTable from '../components/bullet-table';
 import Pills from '../components/pills';
 import {
@@ -661,6 +662,7 @@ class AdminArea extends SFPComponent {
                   </Fold>
                 </TabContent>
                 <TabContent>
+                  <HighlightedOperations opsType='country' opsId={data.id}/>
                   <EmergenciesTable
                     id={'emergencies'}
                     title="Recent Emergencies"

--- a/app/assets/scripts/views/home.js
+++ b/app/assets/scripts/views/home.js
@@ -23,7 +23,7 @@ class Home extends React.Component {
             </div>
           </header>
           <div className='inpage__body inpage__body__main'>
-            <HighlightedOperations />
+            <HighlightedOperations opsType='all'/>
             <PresentationDash />
             <div className='inner'>
               <AlertsTable

--- a/app/assets/scripts/views/home.js
+++ b/app/assets/scripts/views/home.js
@@ -4,7 +4,7 @@ import { Helmet } from 'react-helmet';
 import App from './app';
 import PresentationDash from '../components/connected/presentation-dash';
 import AlertsTable from '../components/connected/alerts-table';
-import FeaturedEmergencies from '../components/connected/featured-emergencies';
+import HighlightedOperations from '../components/highlighted-operations';
 
 class Home extends React.Component {
   render () {
@@ -23,7 +23,7 @@ class Home extends React.Component {
             </div>
           </header>
           <div className='inpage__body inpage__body__main'>
-            <FeaturedEmergencies />
+            <HighlightedOperations />
             <PresentationDash />
             <div className='inner'>
               <AlertsTable

--- a/app/assets/scripts/views/region.js
+++ b/app/assets/scripts/views/region.js
@@ -55,6 +55,7 @@ import Fold from '../components/fold';
 import TabContent from '../components/tab-content';
 import BlockLoading from '../components/block-loading';
 import EmergenciesTable from '../components/connected/emergencies-table';
+import HighlightedOperations from '../components/highlighted-operations';
 import AppealsTable from '../components/connected/appeals-table';
 import {
   Snippets,
@@ -400,6 +401,7 @@ class AdminArea extends SFPComponent {
             <div className='inner'>
               <TabPanel>
                 <TabContent>
+                  <HighlightedOperations opsType='region' opsId={data.id}/>
                   <div className={c('fold', {presenting: this.state.fullscreen})} id='presentation'>
                     {this.state.fullscreen ? (<FullscreenHeader title='IFRC Disaster Response and Preparedness'/>) : null}
                     <div className={c('inner', {'appeals--fullscreen': this.state.fullscreen})}>

--- a/app/assets/styles/home/_global.scss
+++ b/app/assets/styles/home/_global.scss
@@ -307,12 +307,10 @@
 
 .progress-bar {
   background: $grey-slate;
-  border-radius: $full-border-radius;
   width: 100%;
 
   &__value {
     background: $secondary-color;
-    border-radius: $full-border-radius;
     //height: 0.875rem;
     height: 9px;
 

--- a/app/assets/styles/home/_highlighted-emergencies.scss
+++ b/app/assets/styles/home/_highlighted-emergencies.scss
@@ -51,54 +51,15 @@
 }
 
 .card_box_full {
-  //float: left;
-  //margin-top: 1rem;
-  //padding-top: 0.5rem;
-  //border-top: 1px solid base-border-color;
   width: 100%;
-  //font-size: 1.5rem;
   text-align: left;
+  padding: $global-spacing $global-spacing ($global-spacing / 2) $global-spacing;
+  justify-content: space-between;
+  align-items: baseline;
 
   .progress-bar {
-    //display: inline-block;
     width: 80%;
   }
-
-  //small {
-    //display: block;
-    //font-size: 0.875rem;
-    //text-transform: uppercase;
-    //color: rgba(0, 0, 0, 0.6);
-  //}
-
-  .progress-bar-container {
-    margin-top: -10px;
-  }
-
-  //.progress-bar__value {
-    //background-color: $secondary-color;
-  //}
-
-  //.progress-bar__key small {
-    //display: inline-block;
-    //@include media(xsmall-only) {
-      //font-size: 0.7rem;    
-    //}
-    //@include media(small-only) {
-      //font-size: 0.875rem;    
-    //}
-    //@include media(medium-only) {
-      //font-size: 0.65rem;    
-    //}
-    //@include media(large-only) {
-      //font-size: 0.835rem;    
-    //}
-    //@include media(xlarge-only) {
-      //font-size: 0.875rem;    
-    //}
-    //text-transform: uppercase;
-    //color: rgba(0, 0, 0, 0.6);
-  //}
 
   .progress-bar__key {
     display: inline-block;
@@ -107,6 +68,10 @@
     width: 20%;
     float: right;
   }
+}
+
+.card_box_footer {
+  margin-bottom: ($global-spacing / 2);
 }
 
 .more_button {


### PR DESCRIPTION
## Description
- Renamed `featured-emergencies` to `highlighted-operations`
- Updated deprecated react life-cycles
- Extracted cards into separate component
- Created filters for region and country pages
- Added Highlighted Ops to region and country pages
- Limited the display of cards to the first 3 (they are ordered by most recent by default)
- Added conditional that hides this feature if there are no operations that pertain to the page
- Changed progress bar border radiuses to corners
- Turned bottom boxes into one full boxes and aligned text to match designs
- Added spacing below the progress bar to match design
- Removed conditional so that progress bar is displayed even if there is 0% funding 
- Deleted dead code in styles

## Related Issue
#846 

## Motivation and Context
- Applies Highlighted Operations to other applicable pages
- Updates styles to match designs

## Screenshots (if appropriate):
Home page:
![image](https://user-images.githubusercontent.com/20410256/68481073-39bc7c00-0204-11ea-8e62-2e5ce3eba1a1.png)

Region page (Africa):
![image](https://user-images.githubusercontent.com/20410256/68481150-725c5580-0204-11ea-9c1e-cdbb582c6ca3.png)

Country page (Angola):
![image](https://user-images.githubusercontent.com/20410256/68481216-9ae44f80-0204-11ea-9d3c-0ab1976b8077.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
