### PR TITLE
allow maxZoom 8 to get country labels to show properly

### DIFF
--- a/app/assets/scripts/utils/get-new-map.js
+++ b/app/assets/scripts/utils/get-new-map.js
@@ -10,7 +10,7 @@ export default function newMap (container, mapStyle = 'mapbox://styles/go-ifrc/c
     style: mapStyle,
     zoom: 1.5,
     minZoom: 1,
-    maxZoom: 6,
+    maxZoom: 8,
     scrollZoom: false,
     pitchWithRotate: false,
     dragRotate: false,


### PR DESCRIPTION
Quick fix to show labels. Changes maxZoom on the map from 6 to 8.