### PR TITLE
removes space between cards on region

### DIFF
--- a/app/assets/styles/home/_global.scss
+++ b/app/assets/styles/home/_global.scss
@@ -125,7 +125,7 @@
   }
 
   @include media(large-up) {
-    justify-content: space-between;
+    justify-content: center;
   }
 
   @include media(large-up) {


### PR DESCRIPTION
Updates spacing between key figures on region page per request on #852 

![image](https://user-images.githubusercontent.com/20410256/69269932-01bc1e00-0ba0-11ea-8875-f629b4e9c1fa.png)
![image](https://user-images.githubusercontent.com/20410256/69270108-58c1f300-0ba0-11ea-91fe-b3fa71c6655b.png)

Home page design is unaffected:
![image](https://user-images.githubusercontent.com/20410256/69270019-2ca67200-0ba0-11ea-88d8-5665e66358a1.png)
