### PR TITLE
Fix/828 key figures presentation

### DIFF
--- a/app/assets/scripts/views/region.js
+++ b/app/assets/scripts/views/region.js
@@ -204,7 +204,10 @@ class AdminArea extends SFPComponent {
                   <HighlightedOperations opsType='region' opsId={data.id}/>
                   <div className={c('fold', {presenting: this.state.fullscreen})} id='presentation'>
                     {this.state.fullscreen ? (
-                      <FullscreenHeader title='IFRC Disaster Response and Preparedness'/>
+                      <React.Fragment>
+                        <FullscreenHeader title='IFRC Disaster Response and Preparedness'/>
+                        <KeyFiguresHeader appealsList={this.props.appealStats} keyFiguresList={['numBeneficiaries', 'amountRequested', 'amountFunded']}/>
+                      </React.Fragment>
                     ) : null}
                     <div className={c('inner', {'appeals--fullscreen': this.state.fullscreen})}>
                       <AppealsTable

--- a/app/assets/scripts/views/region.js
+++ b/app/assets/scripts/views/region.js
@@ -8,7 +8,6 @@ import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 import { Helmet } from 'react-helmet';
 import CountryList from '../components/country-list';
 import { environment } from '../config';
-import FullscreenHeader from '../components/common/fullscreen-header';
 import { showGlobalLoading, hideGlobalLoading } from '../components/global-loading';
 import { get } from '../utils/utils/';
 import { nope } from '../utils/format';

--- a/app/assets/scripts/views/region.js
+++ b/app/assets/scripts/views/region.js
@@ -163,6 +163,11 @@ class AdminArea extends SFPComponent {
 
     if (!fetched || error) return null;
 
+    const presentationClass = c({
+      'presenting fold--stats': this.state.fullscreen,
+      'fold': !this.state.fullscreen
+    });
+
     const mapBoundingBox = getRegionBoundingBox(data.id);
     const regionName = get(regionMeta, [data.id, 'name'], nope);
     const activeOperations = get(this.props.appealStats, 'data.results.length', false);
@@ -202,12 +207,9 @@ class AdminArea extends SFPComponent {
               <TabPanel>
                 <TabContent>
                   <HighlightedOperations opsType='region' opsId={data.id}/>
-                  <div className={c('fold', {presenting: this.state.fullscreen})} id='presentation'>
+                  <section className={presentationClass} id='presentation'>
                     {this.state.fullscreen ? (
-                      <React.Fragment>
-                        <FullscreenHeader title='IFRC Disaster Response and Preparedness'/>
-                        <KeyFiguresHeader appealsList={this.props.appealStats} keyFiguresList={['numBeneficiaries', 'amountRequested', 'amountFunded']}/>
-                      </React.Fragment>
+                      <KeyFiguresHeader fullscreen={this.state.fullscreen} appealsList={this.props.appealStats} keyFiguresList={['numBeneficiaries', 'amountRequested', 'amountFunded']}/>
                     ) : null}
                     <div className={c('inner', {'appeals--fullscreen': this.state.fullscreen})}>
                       <AppealsTable
@@ -226,7 +228,7 @@ class AdminArea extends SFPComponent {
                         toggleFullscreen={this.toggleFullscreen}
                       />
                     </div>
-                  </div>
+                  </section>
                   <Fold title='Statistics' headerClass='visually-hidden' id='stats'>
                     <div className='stats-chart'>
                       <TimelineCharts region={data.id} />

--- a/app/assets/styles/home/_presenting.scss
+++ b/app/assets/styles/home/_presenting.scss
@@ -92,7 +92,7 @@
 .inpage__title--map-fullscreen {
   padding-left: 400px; // width of logo + some padding
   margin: ($global-spacing/2) 0 0 0;
-  text-align: left;
+  text-align: center;
   font-size: 2rem;
   width: 100%;
 }


### PR DESCRIPTION
#828
I added in the key figures and updated the header styles.
There were two problems that contributed to the styling misalignment:
- there were nested styles on home that were overriding styles on home but not on region. Since the style on home are the preferred styles, I just changed the presentation title styles to reflect the text alignment would be preserved without overriding anything
- There was a difference in class names for the section containing the map on the region and home page. I added some conditionals to allow the classnames on the region to persist while using the same classnames as the home page on presentation mode.

region:
![image](https://user-images.githubusercontent.com/20410256/69745813-f2455380-1110-11ea-91e7-f546a0ee61a8.png)

home page (unmodified):
![image](https://user-images.githubusercontent.com/20410256/69745867-1012b880-1111-11ea-8e0b-9b17c3100392.png)

