### PR TITLE
remove unneeded reference to hard-coded actions

### DIFF
--- a/app/assets/scripts/views/field-report-form/data-utils.js
+++ b/app/assets/scripts/views/field-report-form/data-utils.js
@@ -359,24 +359,15 @@ export function getInitialDataState () {
     bulletin: undefined,
     actionsOthers: undefined,
     actionsNatSoc: {
-      options: formData.actions.map(o => ({
-        value: o.value,
-        checked: false
-      })),
+      options: [],
       description: undefined
     },
     actionsPns: {
-      options: formData.actions.map(o => ({
-        value: o.value,
-        checked: false
-      })),
+      options: [],
       description: undefined
     },
     actionsFederation: {
-      options: formData.actions.map(o => ({
-        value: o.value,
-        checked: false
-      })),
+      options: [],
       description: undefined
     },
 


### PR DESCRIPTION
Fixes an over-sight, forgot to remove references to hard-coded actions.