### PR TITLE
updates styles to accomodate 4-6 ops

### DIFF
--- a/app/assets/scripts/components/highlighted-operations/index.js
+++ b/app/assets/scripts/components/highlighted-operations/index.js
@@ -86,8 +86,6 @@ class HighlightedOperations extends React.Component {
     ) : (
       'key-emergencies-list key-emergencies-list-long'
     );
-    operations.push(operations[0])
-    console.log('operations', operations)
     return (operations.length ? (
       <div className='inner inner--emergencies'>
         <Fold title={title} navLink={foldLink} extraClass foldClass='fold__title--inline'>

--- a/app/assets/scripts/components/highlighted-operations/index.js
+++ b/app/assets/scripts/components/highlighted-operations/index.js
@@ -81,18 +81,24 @@ class HighlightedOperations extends React.Component {
     if (this.props.opsType === 'country') {
       operations = operations.filter(op => op.countries[0].id === this.props.opsId);
     }
+    const listStyle = operations.length <= 4 ? (
+      'key-emergencies-list key-emergencies-list-short'
+    ) : (
+      'key-emergencies-list key-emergencies-list-long'
+    );
+    operations.push(operations[0])
+    console.log('operations', operations)
     return (operations.length ? (
       <div className='inner inner--emergencies'>
         <Fold title={title} navLink={foldLink} extraClass foldClass='fold__title--inline'>
-          <ul className='key-emergencies-list'>
-            {/* displays the first three operations sorted by most recent by default */}
-            {operations.slice(0, 3).map(operation =>
+          <div className={listStyle}>
+            {operations.slice(0, 6).map(operation =>
               <OperationCard
                 operation={operation}
                 calculateDeployedPersonnel={this.calculateDeployedPersonnel}
               />
             )}
-          </ul>
+          </div>
         </Fold>
       </div>
     ) : null

--- a/app/assets/scripts/components/highlighted-operations/operation-card.js
+++ b/app/assets/scripts/components/highlighted-operations/operation-card.js
@@ -15,7 +15,7 @@ const OperationCard = ({operation, calculateDeployedPersonnel}) => {
   const emergencyDeployments = calculateDeployedPersonnel(operation);
 
   return (
-    <li className='key-emergencies-item' key={id}>
+    <div className='key-emergencies-item' key={id}>
       <Link to={`/emergencies/${id}`}>
         <div className="card_box card_box_left">
           <h2 className='card__title'>{ name.length > 30 ? name.slice(0, 30) + '...' : name }</h2>
@@ -55,7 +55,7 @@ const OperationCard = ({operation, calculateDeployedPersonnel}) => {
           <Progress value={requested ? percent(funded, requested) : percent(0.1, 10)} max={100} />
         </div>
       </Link>
-    </li>
+    </div>
   );
 };
 

--- a/app/assets/styles/home/_global.scss
+++ b/app/assets/styles/home/_global.scss
@@ -631,8 +631,17 @@
   font-size: 0.75rem;
 }
 
+.key-emergencies-list-long {
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.key-emergencies-list-short {
+  justify-content: space-between;
+}
+
 .key-emergencies-list {
-  list-style: none;
+  display: flex;
   margin-left: 0;
   @extend .clearfix;
   @include column(12/12);
@@ -652,8 +661,7 @@
 
   .key-emergencies-item {
     //@include column(10/12);
-    //margin-right: 2% !important;
-    display: block;
+    margin-right: 2% !important;
     margin-bottom: $global-spacing;
     @include media(medium-up) {
       @include column(6/12)

--- a/app/assets/styles/home/_global.scss
+++ b/app/assets/styles/home/_global.scss
@@ -634,10 +634,14 @@
 .key-emergencies-list-long {
   flex-wrap: wrap;
   justify-content: center;
+  .key-emergencies-item {
+    margin-right: 2% !important;
+  }
 }
 
 .key-emergencies-list-short {
   justify-content: space-between;
+  flex-wrap: nowrap;
 }
 
 .key-emergencies-list {
@@ -661,7 +665,6 @@
 
   .key-emergencies-item {
     //@include column(10/12);
-    margin-right: 2% !important;
     margin-bottom: $global-spacing;
     @include media(medium-up) {
       @include column(6/12)


### PR DESCRIPTION
#846 
This adds a bit of css hackery that adds different classes depending on list length. 
Looking forward to rewriting this to be a carousel

3: 
![image](https://user-images.githubusercontent.com/20410256/70013403-85352200-1545-11ea-84b8-5591da559c41.png)

4:
![image](https://user-images.githubusercontent.com/20410256/70013384-6c2c7100-1545-11ea-9ce7-8d3c20afef1d.png)

5:
![image](https://user-images.githubusercontent.com/20410256/70013108-89ad0b00-1544-11ea-863e-6883d000ea8c.png)

6:

![image](https://user-images.githubusercontent.com/20410256/70013082-713cf080-1544-11ea-8118-720a8e7c5084.png)

