### PR TITLE
Field Report Fixes

### DIFF
--- a/app/assets/scripts/schemas/field-report-form.js
+++ b/app/assets/scripts/schemas/field-report-form.js
@@ -177,6 +177,12 @@ export const step4 = {
     ifrcStaff: {
       '$ref': '#/definitions/plannedResponse'
     },
+    imminentDref: {
+      '$ref': '#/definitions/plannedResponse'
+    },
+    forecastBasedAction: {
+      '$ref': '#/definitions/plannedResponse'
+    },
     contactOriginator: {
       '$ref': '#/definitions/contact'
     },

--- a/app/assets/scripts/schemas/field-report-form.js
+++ b/app/assets/scripts/schemas/field-report-form.js
@@ -32,6 +32,9 @@ export const step1 = {
     },
     assistance: {
       type: 'boolean'
+    },
+    nsAssistance: {
+      type: 'boolean'
     }
   },
   anyOf: [
@@ -96,6 +99,9 @@ export const step2 = {
       '$ref': '#/definitions/estimationString'
     },
     description: {
+      type: 'string'
+    },
+    otherSources: {
       type: 'string'
     }
   }

--- a/app/assets/scripts/utils/field-report-constants.js
+++ b/app/assets/scripts/utils/field-report-constants.js
@@ -565,6 +565,16 @@ export const fieldsStep1 = {
       label: 'Government requests international assistance?',
       desc: 'Indicate if the government requested international assistance.'
     }
+  },
+  'ns-assistance': {
+    'EVT': {
+      label: 'National Society requests international assistance?',
+      desc: 'Indicate if the National Society requested international assistance'
+    },
+    'EW': {
+      label: 'National Society requests international assistance?',
+      desc: 'Indicate if the National Society requested international assistance'
+    }
   }
 };
 

--- a/app/assets/scripts/utils/field-report-constants.js
+++ b/app/assets/scripts/utils/field-report-constants.js
@@ -759,8 +759,8 @@ export const fieldsStep3 = {
       'EW': 'Early Actions Taken by Others (Governments, UN)'
     },
     'desc': {
-      'EVT': 'Who else was involved? UN agencies? NGOs? Government? Describe what other actors did.',
-      'EW': 'List the early action activities undertaken by other actors and give a brief description.'
+      'EVT': 'Who else was involved? UN agencies? NGOs? Government? Describe what other actors did. Also mention who the other actors are.',
+      'EW': 'List the early action activities undertaken by other actors, mention who the other actors are, and give a brief description.'
     }
   }
 };

--- a/app/assets/scripts/views/field-report-form/cmp-source-estimation.js
+++ b/app/assets/scripts/views/field-report-form/cmp-source-estimation.js
@@ -84,7 +84,7 @@ export default class SourceEstimation extends React.Component {
                 label='Source'
                 name={`${name}[${idx}][source]`}
                 options={[
-                  {label: 'RCRC', value: 'red-cross'},
+                  {label: 'Red Cross/Red Crescent', value: 'red-cross'},
                   {label: 'Government', value: 'government'},
                   {label: 'Other', value: 'other'}
                 ]}

--- a/app/assets/scripts/views/field-report-form/cmp-source-estimation.js
+++ b/app/assets/scripts/views/field-report-form/cmp-source-estimation.js
@@ -84,7 +84,7 @@ export default class SourceEstimation extends React.Component {
                 label='Source'
                 name={`${name}[${idx}][source]`}
                 options={[
-                  {label: 'Red Cross/Red Crescent', value: 'red-cross'},
+                  {label: 'Red Cross / Red Crescent', value: 'red-cross'},
                   {label: 'Government', value: 'government'},
                   {label: 'Other', value: 'other'}
                 ]}

--- a/app/assets/scripts/views/field-report-form/data-utils.js
+++ b/app/assets/scripts/views/field-report-form/data-utils.js
@@ -24,7 +24,9 @@ export function dataPathToDisplay (path, keyword) {
     event: 'Event',
     sources: 'Sources',
     description: 'Brief Description of the Situation',
+    otherSources: 'Details of Other Sources',
     assistance: 'Government requests international assistance?',
+    nsAssistance: 'National Society requests international assistance?',
 
     // Step 2.
     'numInjured.estimation': 'Estimation Injured',
@@ -103,6 +105,7 @@ export function prepStateForValidation (state) {
   const formatter = {
     // Step 1.
     assistance: toBool,
+    nsAssistance: toBool,
     country: (val) => val ? val.value : undefined,
     districts: (val) => val.map(o => o.value),
     // countries: (val) => val.value,
@@ -170,6 +173,7 @@ export function convertStateToPayload (originalState) {
     // [source, destination]
     ['summary', 'summary'],
     ['description', 'description'],
+    ['otherSources', 'other_sources'],
     ['status', 'status'],
     ['bulletin', 'bulletin'],
     ['numAssistedRedCross', 'num_assisted', Number],
@@ -188,7 +192,7 @@ export function convertStateToPayload (originalState) {
 
   // Boolean values
   state.request_assistance = Boolean(originalState.assistance === 'true');
-
+  state.ns_request_assistance = Boolean(originalState.nsAssistance === 'true');
   // For these properties when the source is the Red Cross use the provided,
   // when it's Government prepend gov_. This results in:
   // num_injured | gov_num_injured
@@ -338,7 +342,9 @@ export function getInitialDataState () {
       specification: undefined
     })),
     description: undefined,
+    otherSources: undefined,
     assistance: undefined,
+    nsAssistance: undefined,
 
     // Step 2
     numInjured: [{ estimation: undefined, source: undefined }],
@@ -430,6 +436,7 @@ export function convertFieldReportToState (fieldReport) {
     // [source, destination]
     ['summary', 'summary'],
     ['description', 'description'],
+    ['other_sources', 'otherSources'],
     ['num_assisted', 'numAssistedRedCross'],
     ['gov_num_assisted', 'numAssistedGov'],
     ['num_localstaff', 'numLocalStaff'],
@@ -447,6 +454,7 @@ export function convertFieldReportToState (fieldReport) {
 
   // Boolean values
   state.assistance = fieldReport.request_assistance !== null ? fieldReport.request_assistance.toString() : state.assistance;
+  state.nsAssistance = fieldReport.ns_request_assistance !== null ? fieldReport.ns_request_assistance.toString() : state.nsAssistance;
 
   // For these properties when the source is the Red Cross use the provided,
   // when it's Government starts with gov_. This results in:

--- a/app/assets/scripts/views/field-report-form/data-utils.js
+++ b/app/assets/scripts/views/field-report-form/data-utils.js
@@ -541,9 +541,7 @@ export function convertFieldReportToState (fieldReport) {
     ['forecast_based_action', 'forecast_based_action_amount', 'forecastBasedAction']
   ];
 
-  console.log('field report', fieldReport);
   planResponseMapping.forEach(([statusMap, valueMap, dest]) => {
-    console.log('statusMap', statusMap);
     if (fieldReport[statusMap] !== null) {
       state[dest] = {
         status: fieldReport[statusMap].toString(),

--- a/app/assets/scripts/views/field-report-form/index.js
+++ b/app/assets/scripts/views/field-report-form/index.js
@@ -502,7 +502,7 @@ class FieldReportForm extends React.Component {
               errors={this.state.errors}
               property='otherSources'
             />
-          </FormTextarea>          
+          </FormTextarea>
         </React.Fragment>
         <React.Fragment>
           <FormTextarea

--- a/app/assets/scripts/views/field-report-form/index.js
+++ b/app/assets/scripts/views/field-report-form/index.js
@@ -252,7 +252,7 @@ class FieldReportForm extends React.Component {
       },
       {
         'EVT': 'Situation',
-        'EW': 'Risk'
+        'EW': 'Risk Analysis'
       },
       {
         'EVT': 'Actions',

--- a/app/assets/scripts/views/field-report-form/index.js
+++ b/app/assets/scripts/views/field-report-form/index.js
@@ -440,6 +440,27 @@ class FieldReportForm extends React.Component {
             property='assistance'
           />
         </FormRadioGroup>
+        <FormRadioGroup
+          label={fields['ns-assistance'][status].label}
+          description={fields['ns-assistance'][status].desc}
+          name='ns-assistance'
+          options={[
+            {
+              label: 'Yes',
+              value: 'true'
+            },
+            {
+              label: 'No',
+              value: 'false'
+            }
+          ]}
+          selectedOption={this.state.data.nsAssistance}
+          onChange={this.onFieldChange.bind(this, 'nsAssistance')} >
+          <FormError
+            errors={this.state.errors}
+            property='nsAssistance'
+          />
+        </FormRadioGroup>
       </Fold>
     );
   }
@@ -466,6 +487,22 @@ class FieldReportForm extends React.Component {
               );
             })
           }
+        </React.Fragment>
+        <React.Fragment>
+          <FormTextarea
+            label='Source Details'
+            name='other-sources'
+            classInput='textarea--lg'
+            placeholder='Add details for data with sources marked as Other above.'
+            id='other-sources'
+            description='Add details for sources above (if applicable)'
+            value={this.state.data.otherSources}
+            onChange={this.onFieldChange.bind(this, 'otherSources')} >
+            <FormError
+              errors={this.state.errors}
+              property='otherSources'
+            />
+          </FormTextarea>          
         </React.Fragment>
         <React.Fragment>
           <FormTextarea

--- a/app/assets/styles/field-report/_form.scss
+++ b/app/assets/styles/field-report/_form.scss
@@ -188,6 +188,11 @@
     @include media(large-up) {
       @include column(6/12);
     }
+
+    .form__option--inline {
+      margin-left: 0;
+      display: flex;
+    }
   }
 
   .estimation__item-field {


### PR DESCRIPTION
Addresses the following fixes:

 - Change `Risk` to `Risk Analysis` in stepper for Early Warning
 - Change source label `RCRC` to `Red Cross / Red Crescent` - fix styling for labels to accomodate longer labels.
 - Adds to additional fields to the Field Report as per #880 

@necoline these are mostly minor fixes, am going to go ahead and merge so things can be tested, but please let me know if anything seems off to you / can be improved.