### PR TITLE
filter highlighted operations by is_featured_region flag

### DIFF
--- a/app/assets/scripts/actions/index.js
+++ b/app/assets/scripts/actions/index.js
@@ -162,6 +162,10 @@ export function getFeaturedEmergencies () {
   return fetchJSON('/api/v2/event/?is_featured=1', GET_FEATURED_EMERGENCIES, withToken());
 }
 
+export function getFeaturedEmergenciesForRegion (regionId) {
+  return fetchJSON(`/api/v2/event/?is_featured_region=1&regions__in=${regionId}`, GET_FEATURED_EMERGENCIES, withToken());
+}
+
 export const GET_FEATURED_EMERGENCIES_DEPLOYMENTS = 'GET_FEATURED_EMERGENCIES_DEPLOYMENTS';
 export function getFeaturedEmergenciesDeployments () {
   return fetchJSON('/api/v2/featured_event_deployments', GET_FEATURED_EMERGENCIES_DEPLOYMENTS, withToken());

--- a/app/assets/scripts/components/highlighted-operations/index.js
+++ b/app/assets/scripts/components/highlighted-operations/index.js
@@ -4,7 +4,6 @@ import { PropTypes as T } from 'prop-types';
 import { Link } from 'react-router-dom';
 import { environment } from '../../config';
 import { getFeaturedEmergencies, getFeaturedEmergenciesForRegion, getFeaturedEmergenciesDeployments, getDeploymentERU } from '../../actions';
-import { countriesByRegion } from '../../utils/region-constants';
 import BlockLoading from '../block-loading';
 import Fold from '../fold';
 import OperationCard from './operation-card';
@@ -79,12 +78,6 @@ class HighlightedOperations extends React.Component {
     if (fetched && (error || !Array.isArray(data.results) || !data.results.length)) return null;
     else if (!fetched || fetching) return <div className='inner'><Fold title={title}><BlockLoading/></Fold></div>;
     let operations = data.results;
-    // if (this.props.opsType === 'region') {
-    //   operations = operations.filter(op => countriesByRegion[this.props.opsId].includes(op.countries[0].id.toString()));
-    // }
-    // if (this.props.opsType === 'country') {
-    //   operations = operations.filter(op => op.countries[0].id === this.props.opsId);
-    // }
     const listStyle = operations.length <= 4 ? (
       'key-emergencies-list key-emergencies-list-short'
     ) : (

--- a/app/assets/scripts/components/highlighted-operations/index.js
+++ b/app/assets/scripts/components/highlighted-operations/index.js
@@ -21,7 +21,7 @@ class HighlightedOperations extends React.Component {
 
   componentDidMount () {
     if (this.props.opsType === 'region') {
-      this.props._getFeaturedEmergenciesForRegion(this.props.opsId)
+      this.props._getFeaturedEmergenciesForRegion(this.props.opsId);
     } else {
       this.props._getFeaturedEmergencies();
     }

--- a/app/assets/scripts/components/highlighted-operations/index.js
+++ b/app/assets/scripts/components/highlighted-operations/index.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { PropTypes as T } from 'prop-types';
 import { Link } from 'react-router-dom';
 import { environment } from '../../config';
-import { getFeaturedEmergencies, getFeaturedEmergenciesDeployments, getDeploymentERU } from '../../actions';
+import { getFeaturedEmergencies, getFeaturedEmergenciesForRegion, getFeaturedEmergenciesDeployments, getDeploymentERU } from '../../actions';
 import { countriesByRegion } from '../../utils/region-constants';
 import BlockLoading from '../block-loading';
 import Fold from '../fold';
@@ -20,7 +20,11 @@ class HighlightedOperations extends React.Component {
   }
 
   componentDidMount () {
-    this.props._getFeaturedEmergencies();
+    if (this.props.opsType === 'region') {
+      this.props._getFeaturedEmergenciesForRegion(this.props.opsId)
+    } else {
+      this.props._getFeaturedEmergencies();
+    }
     this.props._getFeaturedEmergenciesDeployments();
   }
 
@@ -75,12 +79,12 @@ class HighlightedOperations extends React.Component {
     if (fetched && (error || !Array.isArray(data.results) || !data.results.length)) return null;
     else if (!fetched || fetching) return <div className='inner'><Fold title={title}><BlockLoading/></Fold></div>;
     let operations = data.results;
-    if (this.props.opsType === 'region') {
-      operations = operations.filter(op => countriesByRegion[this.props.opsId].includes(op.countries[0].id.toString()));
-    }
-    if (this.props.opsType === 'country') {
-      operations = operations.filter(op => op.countries[0].id === this.props.opsId);
-    }
+    // if (this.props.opsType === 'region') {
+    //   operations = operations.filter(op => countriesByRegion[this.props.opsId].includes(op.countries[0].id.toString()));
+    // }
+    // if (this.props.opsType === 'country') {
+    //   operations = operations.filter(op => op.countries[0].id === this.props.opsId);
+    // }
     const listStyle = operations.length <= 4 ? (
       'key-emergencies-list key-emergencies-list-short'
     ) : (
@@ -107,13 +111,14 @@ class HighlightedOperations extends React.Component {
 if (environment !== 'production') {
   HighlightedOperations.propTypes = {
     _getFeaturedEmergencies: T.func,
+    _getFeaturedEmergenciesForRegion: T.func,
     _getFeaturedEmergenciesDeployments: T.func,
     _getDeploymentERU: T.func,
     featured: T.object,
     deployments: T.object,
     eru: T.object,
     opsType: T.string,
-    opsId: T.string,
+    opsId: T.string
   };
 }
 
@@ -125,6 +130,7 @@ const selector = (state) => ({
 
 const dispatcher = (dispatch) => ({
   _getFeaturedEmergencies: (...args) => dispatch(getFeaturedEmergencies(...args)),
+  _getFeaturedEmergenciesForRegion: (...args) => dispatch(getFeaturedEmergenciesForRegion(...args)),
   _getFeaturedEmergenciesDeployments: (...args) => dispatch(getFeaturedEmergenciesDeployments(...args)),
   _getDeploymentERU: (...args) => dispatch(getDeploymentERU(...args))
 });

--- a/app/assets/scripts/views/countries.js
+++ b/app/assets/scripts/views/countries.js
@@ -552,7 +552,7 @@ class AdminArea extends SFPComponent {
                   </Fold>
                 </TabContent>
                 <TabContent>
-                  <HighlightedOperations opsType='country' opsId={data.id}/>
+                  {/* <HighlightedOperations opsType='country' opsId={data.id}/> */ }
                   <EmergenciesTable
                     id={'emergencies'}
                     title="Recent Emergencies"

--- a/app/assets/scripts/views/countries.js
+++ b/app/assets/scripts/views/countries.js
@@ -43,7 +43,7 @@ import TabContent from '../components/tab-content';
 import Fold from '../components/fold';
 import DisplayTable, { SortHeader, FilterHeader } from '../components/display-table';
 import EmergenciesTable from '../components/connected/emergencies-table';
-import HighlightedOperations from '../components/highlighted-operations';
+
 // import BulletTable from '../components/bullet-table';
 import Pills from '../components/pills';
 import {
@@ -552,7 +552,6 @@ class AdminArea extends SFPComponent {
                   </Fold>
                 </TabContent>
                 <TabContent>
-                  {/* <HighlightedOperations opsType='country' opsId={data.id}/> */ }
                   <EmergenciesTable
                     id={'emergencies'}
                     title="Recent Emergencies"


### PR DESCRIPTION
This PR implements the filter to show Highlighted Operations on the Region page that are marked as `if_featured_region` on the backend.

@necoline I wasn't sure what the behaviour should be on the Country page. I have commented it out in the code for now, and would ideally just drop it from the country page, but we should discuss this.

I find it a bit awkward that I'm re-using the `GET_FEATURED_EMERGENCIES` action type in the action: https://github.com/IFRCGo/go-frontend/compare/feature/filter-region-ops?expand=1#diff-5c355adac55012fbbb2981b6d27b1742R166 - I think it's probably fine, but @necoline let me know if you think that should be done differently.

This seems to work and I tested locally with the backend. I am a bit confused by the `getFeaturedEmergenciesDeployments` action and the query it makes - it does not seem to apply any filters on the API, so have left it as is, but is possibly something to ticket out / improve later.

@necoline would be great to have a review.

TODO before merging:

 - [x] Decide what to do with Highlighted Ops on country page
 - [x] Remove commented out bits of code
