### PR TITLE
Fix/839 update date table

### DIFF
--- a/app/assets/scripts/components/common/filters/date-filter-header.js
+++ b/app/assets/scripts/components/common/filters/date-filter-header.js
@@ -11,6 +11,7 @@ export default class DateFilterHeader extends React.PureComponent {
     this.state = {
       startDate: null,
       endDate: null,
+      setDate: null,
       isClosingDropdown: false
     };
     this.resetDateStatus = this.resetDateStatus.bind(this);
@@ -32,6 +33,11 @@ export default class DateFilterHeader extends React.PureComponent {
   applyPeriodFilter () {
     this.props.onSelect({'startDate': this.state.startDate, 'endDate': this.state.endDate});
     this.setState({ isClosingDropdown: true });
+    this.state.startDate && this.state.endDate ? (
+      this.setState({ setDate: `${this.state.startDate} - ${this.state.endDate}` })
+    ) : (
+      this.setState({ setDate: null })
+    )
   }
 
   changeStartDate (e) {
@@ -52,7 +58,7 @@ export default class DateFilterHeader extends React.PureComponent {
         id={id}
         triggerClassName={featureType === 'map' ? mapStyle : tableStyle}
         triggerActiveClassName='active'
-        triggerText={title}
+        triggerText={this.state.setDate || title}
         triggerTitle={`Filter by ${title}`}
         triggerElement='a'
         isClosingDropdown={this.state.isClosingDropdown}

--- a/app/assets/scripts/components/common/filters/date-filter-header.js
+++ b/app/assets/scripts/components/common/filters/date-filter-header.js
@@ -37,7 +37,7 @@ export default class DateFilterHeader extends React.PureComponent {
       this.setState({ setDate: `${this.state.startDate} - ${this.state.endDate}` })
     ) : (
       this.setState({ setDate: null })
-    )
+    );
   }
 
   changeStartDate (e) {

--- a/app/assets/scripts/components/connected/appeals-table.js
+++ b/app/assets/scripts/components/connected/appeals-table.js
@@ -152,30 +152,57 @@ class AppealsTable extends SFPComponent {
           label: <DateFilterHeader id='date'
             title='Start Date' options={dateOptions}
             filter={this.state.table.filters.date}
+            isInactive={this.state.table.filters.date === 'all'}
             featureType='table'
             onSelect={this.handleFilterChange.bind(this, 'table', 'date')} />
         },
         {
           id: 'type',
-          label: <FilterHeader id='type' title='Type' options={appealTypeOptions} filter={this.state.table.filters.atype} onSelect={this.handleFilterChange.bind(this, 'table', 'atype')} />
+          label: <FilterHeader
+            id='type'
+            title='Type'
+            options={appealTypeOptions}
+            filter={this.state.table.filters.atype}
+            isInactive={this.state.table.filters.atype === 'all'}
+            onSelect={this.handleFilterChange.bind(this, 'table', 'atype')} />
         },
         { id: 'code', label: 'Code' },
         {
           id: 'name',
-          label: <SortHeader id='name' title='Name' sort={this.state.table.sort} onClick={this.handleSortChange.bind(this, 'table', 'name')} />
+          label: <SortHeader
+            id='name'
+            title='Name'
+            sort={this.state.table.sort}
+            isInactive={!this.state.table.sort.field}
+            onClick={this.handleSortChange.bind(this, 'table', 'name')} />
         },
         { id: 'event', label: 'Emergency' },
         {
           id: 'dtype',
-          label: <FilterHeader id='dtype' title='Disaster Type' options={dTypeOptions} filter={this.state.table.filters.dtype} onSelect={this.handleFilterChange.bind(this, 'table', 'dtype')} />
+          label: <FilterHeader
+            id='dtype'
+            title='Disaster Type'
+            options={dTypeOptions} filter={this.state.table.filters.dtype}
+            isInactive={this.state.table.filters.dtype === 'all'}
+            onSelect={this.handleFilterChange.bind(this, 'table', 'dtype')} />
         },
         {
           id: 'requestAmount',
-          label: <SortHeader id='amount_requested' title='Requested Amount (CHF)' sort={this.state.table.sort} onClick={this.handleSortChange.bind(this, 'table', 'amount_requested')} />
+          label: <SortHeader
+            id='amount_requested'
+            title='Requested Amount (CHF)'
+            sort={this.state.table.sort}
+            isInactive={!this.state.table.sort.field}
+            onClick={this.handleSortChange.bind(this, 'table', 'amount_requested')} />
         },
         {
           id: 'fundedAmount',
-          label: <SortHeader id='amount_funded' title='Funding (CHF)' sort={this.state.table.sort} onClick={this.handleSortChange.bind(this, 'table', 'amount_funded')} />
+          label: <SortHeader
+            id='amount_funded'
+            title='Funding (CHF)'
+            sort={this.state.table.sort}
+            isInactive={!this.state.table.sort.field}
+            onClick={this.handleSortChange.bind(this, 'table', 'amount_funded')} />
         },
         {
           id: 'country',

--- a/app/assets/scripts/components/connected/appeals-table.js
+++ b/app/assets/scripts/components/connected/appeals-table.js
@@ -128,7 +128,6 @@ class AppealsTable extends SFPComponent {
     } = this.props.appeals;
 
     const title = this.props.title || 'Operations Overview';
-
     if (fetching) {
       return (
         <Fold title={title} id={this.props.id}>
@@ -173,7 +172,7 @@ class AppealsTable extends SFPComponent {
             id='name'
             title='Name'
             sort={this.state.table.sort}
-            isInactive={!this.state.table.sort.field}
+            isInactive={this.state.table.sort.field !== 'name'}
             onClick={this.handleSortChange.bind(this, 'table', 'name')} />
         },
         { id: 'event', label: 'Emergency' },
@@ -192,7 +191,7 @@ class AppealsTable extends SFPComponent {
             id='amount_requested'
             title='Requested Amount (CHF)'
             sort={this.state.table.sort}
-            isInactive={!this.state.table.sort.field}
+            isInactive={this.state.table.sort.field !== 'amount_requested'}
             onClick={this.handleSortChange.bind(this, 'table', 'amount_requested')} />
         },
         {
@@ -201,7 +200,7 @@ class AppealsTable extends SFPComponent {
             id='amount_funded'
             title='Funding (CHF)'
             sort={this.state.table.sort}
-            isInactive={!this.state.table.sort.field}
+            isInactive={this.state.table.sort.field !== 'amount_funded'}
             onClick={this.handleSortChange.bind(this, 'table', 'amount_funded')} />
         },
         {

--- a/app/assets/scripts/components/connected/appeals-table.js
+++ b/app/assets/scripts/components/connected/appeals-table.js
@@ -151,7 +151,7 @@ class AppealsTable extends SFPComponent {
           label: <DateFilterHeader id='date'
             title='Start Date' options={dateOptions}
             filter={this.state.table.filters.date}
-            isInactive={this.state.table.filters.date === 'all'}
+            isActive={this.state.table.filters.date !== 'all'}
             featureType='table'
             onSelect={this.handleFilterChange.bind(this, 'table', 'date')} />
         },
@@ -162,7 +162,7 @@ class AppealsTable extends SFPComponent {
             title='Type'
             options={appealTypeOptions}
             filter={this.state.table.filters.atype}
-            isInactive={this.state.table.filters.atype === 'all'}
+            isActive={this.state.table.filters.atype !== 'all'}
             onSelect={this.handleFilterChange.bind(this, 'table', 'atype')} />
         },
         { id: 'code', label: 'Code' },
@@ -172,7 +172,7 @@ class AppealsTable extends SFPComponent {
             id='name'
             title='Name'
             sort={this.state.table.sort}
-            isInactive={this.state.table.sort.field !== 'name'}
+            isActive={this.state.table.sort.field === 'name'}
             onClick={this.handleSortChange.bind(this, 'table', 'name')} />
         },
         { id: 'event', label: 'Emergency' },
@@ -182,7 +182,7 @@ class AppealsTable extends SFPComponent {
             id='dtype'
             title='Disaster Type'
             options={dTypeOptions} filter={this.state.table.filters.dtype}
-            isInactive={this.state.table.filters.dtype === 'all'}
+            isActive={this.state.table.filters.dtype !== 'all'}
             onSelect={this.handleFilterChange.bind(this, 'table', 'dtype')} />
         },
         {
@@ -191,7 +191,7 @@ class AppealsTable extends SFPComponent {
             id='amount_requested'
             title='Requested Amount (CHF)'
             sort={this.state.table.sort}
-            isInactive={this.state.table.sort.field !== 'amount_requested'}
+            isActive={this.state.table.sort.field === 'amount_requested'}
             onClick={this.handleSortChange.bind(this, 'table', 'amount_requested')} />
         },
         {
@@ -200,7 +200,7 @@ class AppealsTable extends SFPComponent {
             id='amount_funded'
             title='Funding (CHF)'
             sort={this.state.table.sort}
-            isInactive={this.state.table.sort.field !== 'amount_funded'}
+            isActive={this.state.table.sort.field === 'amount_funded'}
             onClick={this.handleSortChange.bind(this, 'table', 'amount_funded')} />
         },
         {

--- a/app/assets/scripts/components/display-table.js
+++ b/app/assets/scripts/components/display-table.js
@@ -77,8 +77,8 @@ export default class DisplayTable extends React.Component {
             <tr>
               {this.props.headings.map(h => {
                 const {id, className, label, ...rest} = h;
-                const inactiveHeader = label.props && label.props.isInactive ? 'table__header--inactive' : null;
-                return <th key={id} className={c(`table__header--${id}`, className, inactiveHeader)} {...rest}>{label}</th>;
+                const activeHeader = label.props && label.props.isActive ? 'table__header--active' : null;
+                return <th key={id} className={c(`table__header--${id}`, className, activeHeader)} {...rest}>{label}</th>;
               })}
             </tr>
           </thead>

--- a/app/assets/scripts/components/display-table.js
+++ b/app/assets/scripts/components/display-table.js
@@ -77,7 +77,8 @@ export default class DisplayTable extends React.Component {
             <tr>
               {this.props.headings.map(h => {
                 const {id, className, label, ...rest} = h;
-                return <th key={id} className={c(`table__header--${id}`, className)} {...rest}>{label}</th>;
+                const inactiveHeader = label.props && label.props.isInactive ? 'table__header--inactive' : null;
+                return <th key={id} className={c(`table__header--${id}`, className, inactiveHeader)} {...rest}>{label}</th>;
               })}
             </tr>
           </thead>

--- a/app/assets/styles/core/_tables.scss
+++ b/app/assets/styles/core/_tables.scss
@@ -33,9 +33,10 @@
     padding-right: $global-spacing;
   }
 
-  .table__header--inactive {
-    color: rgba($base-font-color, 0.48);
+  .table__header--active {
+    color: $primary-color;
   }
+
 
   thead th {
     color: $base-color;

--- a/app/assets/styles/core/_tables.scss
+++ b/app/assets/styles/core/_tables.scss
@@ -33,6 +33,10 @@
     padding-right: $global-spacing;
   }
 
+  .table__header--inactive {
+    color: rgba($base-font-color, 0.48);
+  }
+
   thead th {
     color: $base-color;
     font-size: 1rem;
@@ -150,6 +154,7 @@
 td.right-align, th.right-align{
   text-align: right;
 }
+
 
 //td.table__cell--requestAmount, td.table__cell--fundedAmount, th.table__header--requestAmount, th.table__header--fundedAmount {
   //text-align: right;

--- a/app/assets/styles/home/_global.scss
+++ b/app/assets/styles/home/_global.scss
@@ -445,6 +445,7 @@
   display: inline-block;
   min-width: 220px;
   width: auto;
+  padding-top: ($global-spacing / 3);
   background-position: right 0.5rem center;
   &:hover {
     opacity: 1;


### PR DESCRIPTION
#839 
- Displays active date on date filter when date range is selected
- Does not change date format to yyyy-mm-dd since we are using html date input and that display change gets very tricky/convoluted very quickly. It looks like the general suggestion is to sub out the html calendar for a custom one with various date format display options. 
- Greys out inactive filter headers on table and changes color to black when active. I went this route because it looked clean to me. I think it could get busy if we changed the background color on active filters since you can have multiple active filters at once. I realize that using grey as the inactive color may convey that the filter is disabled, I am open to suggestions on how to improve this

table with active filters: type, name
![image](https://user-images.githubusercontent.com/20410256/70151818-173e4700-167a-11ea-9b47-5c2284129634.png)

date filter:
![image](https://user-images.githubusercontent.com/20410256/70151752-05f53a80-167a-11ea-9403-0bde3084d67e.png)


