### PR TITLE
Fixes for Field Report frontend

### DIFF
--- a/app/assets/scripts/components/form-elements/input-select.js
+++ b/app/assets/scripts/components/form-elements/input-select.js
@@ -58,7 +58,7 @@ export default function FormInputSelect (props) {
         />
         {children || null}
 
-        {/*<div className="label-secondary global-margin-t">Or</div>*/}
+        {/* <div className="label-secondary global-margin-t">Or</div> */}
 
         <label className='label-secondary global-margin-t'>{selectLabel}</label>
         <Select.Async

--- a/app/assets/scripts/views/field-report.js
+++ b/app/assets/scripts/views/field-report.js
@@ -203,7 +203,7 @@ class FieldReport extends React.Component {
                 {this.renderActionsTaken(data, 'NTLS', 'National Society')}
                 {this.renderActionsTaken(data, 'FDRN', 'IFRC')}
                 {this.renderActionsTaken(data, 'PNS', 'any other RCRC Movement actors') /* instead of PNS Red Cross, go-frontend/issues/822 */ }
-                <DisplaySection title='Actions taken by others' inner={get(data, 'action_others', false)} />
+                <DisplaySection title='Actions taken by others' inner={get(data, 'actions_others', false)} />
                 {this.renderSources(data)}
                 {this.renderContacts(data)}
               </div>

--- a/app/assets/scripts/views/field-report.js
+++ b/app/assets/scripts/views/field-report.js
@@ -57,7 +57,8 @@ class FieldReport extends React.Component {
       ['Emergency Appeal', getResponseStatus(data, 'appeal')],
       ['RDRT/RITS', getResponseStatus(data, 'rdrt')],
       ['Rapid Response Personnel', getResponseStatus(data, 'fact')],
-      ['IFRC Staff', getResponseStatus(data, 'ifrc_staff')]
+      ['IFRC Staff', getResponseStatus(data, 'ifrc_staff')],
+      ['Forecast Based Response', getResponseStatus(data, 'forecast_based_response')]
     ].filter(d => Boolean(d[1]));
 
     // Every response is either 0 (not planned) or null.
@@ -126,9 +127,126 @@ class FieldReport extends React.Component {
     );
   }
 
+  /**
+   * Gets the status of the FR - either `EVT` for Event or `EW` for Early Warning
+   * Defaults to `EVT` if the status is some-how neither.
+   */
+  getStatus () {
+    const { data } = this.props.report;
+    const status = data.status;
+    if (status === '8') {
+      return 'EVT';
+    }
+    if (status === '9') {
+      return 'EW';
+    }
+    return 'EVT';
+  }
+
+  renderNumericDetails (data) {
+    const status = this.getStatus();
+    const evtHtml = (
+      <React.Fragment>
+        <dl className='dl-horizontal numeric-list'>
+          <dt>Injured (RC): </dt>
+          <dd>{n(get(data, 'num_injured'))}</dd>
+          <dt>Missing (RC): </dt>
+          <dd>{n(get(data, 'num_missing'))}</dd>
+          <dt>Dead (RC): </dt>
+          <dd>{n(get(data, 'num_dead'))}</dd>
+          <dt>Displaced (RC): </dt>
+          <dd>{n(get(data, 'num_displaced'))}</dd>
+          <dt>Affected (RC): </dt>
+          <dd>{n(get(data, 'num_affected'))}</dd>
+        </dl>
+        <dl className='dl-horizontal numeric-list'>
+          <dt>Injured (Government): </dt>
+          <dd>{n(get(data, 'gov_num_injured'))}</dd>
+          <dt>Missing (Government): </dt>
+          <dd>{n(get(data, 'gov_num_missing'))}</dd>
+          <dt>Dead (Government): </dt>
+          <dd>{n(get(data, 'gov_num_dead'))}</dd>
+          <dt>Displaced (Government): </dt>
+          <dd>{n(get(data, 'gov_num_displaced'))}</dd>
+          <dt>Affected (Government): </dt>
+          <dd>{n(get(data, 'gov_num_affected'))}</dd>
+        </dl>
+        <dl className='dl-horizontal numeric-list'>
+          <dt>Injured (Other): </dt>
+          <dd>{n(get(data, 'other_num_injured'))}</dd>
+          <dt>Missing (Other): </dt>
+          <dd>{n(get(data, 'other_num_missing'))}</dd>
+          <dt>Dead (Other): </dt>
+          <dd>{n(get(data, 'other_num_dead'))}</dd>
+          <dt>Displaced (Other): </dt>
+          <dd>{n(get(data, 'other_num_displaced'))}</dd>
+          <dt>Affected (Other): </dt>
+          <dd>{n(get(data, 'other_num_affected'))}</dd>
+        </dl>
+        <dl className='dl-horizontal numeric-list'>
+          <dt>Assisted by Government:</dt>
+          <dd>{n(get(data, 'gov_num_assisted'))}</dd>
+          <dt>Assisted by RCRC Movement:</dt>
+          <dd>{n(get(data, 'num_assisted'))}</dd>
+          <dt>Local Staff: </dt>
+          <dd>{n(get(data, 'num_localstaff'))}</dd>
+          <dt>Volunteers: </dt>
+          <dd>{n(get(data, 'num_volunteers'))}</dd>
+          <dt>Expats/Delegates: </dt>
+          <dd>{n(get(data, 'num_expats_delegates'))}</dd>
+        </dl>
+      </React.Fragment>
+    );
+
+    const ewHtml = (
+      <React.Fragment>
+        <dl className='dl-horizontal numeric-list'>
+          <dt>Potentially Affected (RC): </dt>
+          <dd>{n(get(data, 'num_potentially_affected'))}</dd>
+          <dt>People at Highest Risk (RC): </dt>
+          <dd>{n(get(data, 'num_highest_risk'))}</dd>
+          <dt>Affected Pop Centres (RC): </dt>
+          <dd>{get(data, 'affected_pop_centres')}</dd>
+        </dl>
+        <dl className='dl-horizontal numeric-list'>
+          <dt>Potentially Affected (Government): </dt>
+          <dd>{n(get(data, 'gov_num_potentially_affected'))}</dd>
+          <dt>People at Highest Risk (Government): </dt>
+          <dd>{n(get(data, 'gov_num_highest_risk'))}</dd>
+          <dt>Affected Pop Centres (Government): </dt>
+          <dd>{get(data, 'gov_affected_pop_centres')}</dd>
+        </dl>
+        <dl className='dl-horizontal numeric-list'>
+          <dt>Potentially Affected (Other): </dt>
+          <dd>{n(get(data, 'other_num_potentially_affected'))}</dd>
+          <dt>People at Highest Risk (Other): </dt>
+          <dd>{n(get(data, 'other_num_highest_risk'))}</dd>
+          <dt>Affected Pop Centres (Other): </dt>
+          <dd>{get(data, 'other_affected_pop_centres')}</dd>
+        </dl>
+        <dl className='dl-horizontal numeric-list'>
+          <dt>Assisted by Government:</dt>
+          <dd>{n(get(data, 'gov_num_assisted'))}</dd>
+          <dt>Assisted by RCRC Movement:</dt>
+          <dd>{n(get(data, 'num_assisted'))}</dd>
+        </dl>
+      </React.Fragment>
+    )
+    return (
+      <React.Fragment>
+        <DisplaySection title='Numeric details'>
+          { status === 'EVT' ? evtHtml : ewHtml }
+        </DisplaySection>
+        <DisplaySection
+          title='Other Sources'
+          inner={get(data, 'other_sources', false)}
+        />
+      </React.Fragment>
+    );
+  }
+
   renderContent () {
     const { data } = this.props.report;
-
     if (!this.props.report.fetched || !data) {
       return null;
     }
@@ -160,59 +278,7 @@ class FieldReport extends React.Component {
             <div className='prose fold prose--responsive'>
               <div className='inner'>
                 <p className='inpage__note'>Last updated{data.user ? ` by ${data.user.username}` : null} on {lastTouchedAt}</p>
-                <DisplaySection title='Numeric details'>
-                  <dl className='dl-horizontal numeric-list'>
-                    <dt>Injured (RC): </dt>
-                    <dd>{n(get(data, 'num_injured'))}</dd>
-                    <dt>Missing (RC): </dt>
-                    <dd>{n(get(data, 'num_missing'))}</dd>
-                    <dt>Dead (RC): </dt>
-                    <dd>{n(get(data, 'num_dead'))}</dd>
-                    <dt>Displaced (RC): </dt>
-                    <dd>{n(get(data, 'num_displaced'))}</dd>
-                    <dt>Affected (RC): </dt>
-                    <dd>{n(get(data, 'num_affected'))}</dd>
-                    <dt>Assisted (RC): </dt>
-                    <dd>{n(get(data, 'num_assisted'))}</dd>
-                  </dl>
-                  <dl className='dl-horizontal numeric-list'>
-                    <dt>Injured (Government): </dt>
-                    <dd>{n(get(data, 'gov_num_injured'))}</dd>
-                    <dt>Missing (Government): </dt>
-                    <dd>{n(get(data, 'gov_num_missing'))}</dd>
-                    <dt>Dead (Government): </dt>
-                    <dd>{n(get(data, 'gov_num_dead'))}</dd>
-                    <dt>Displaced (Government): </dt>
-                    <dd>{n(get(data, 'gov_num_displaced'))}</dd>
-                    <dt>Affected (Government): </dt>
-                    <dd>{n(get(data, 'gov_num_affected'))}</dd>
-                    <dt>Assisted (Government): </dt>
-                    <dd>{n(get(data, 'gov_num_assisted'))}</dd>
-                  </dl>
-                  <dl className='dl-horizontal numeric-list'>
-                    <dt>Injured (Other): </dt>
-                    <dd>{n(get(data, 'other_num_injured'))}</dd>
-                    <dt>Missing (Other): </dt>
-                    <dd>{n(get(data, 'other_num_missing'))}</dd>
-                    <dt>Dead (Other): </dt>
-                    <dd>{n(get(data, 'other_num_dead'))}</dd>
-                    <dt>Displaced (Other): </dt>
-                    <dd>{n(get(data, 'other_num_displaced'))}</dd>
-                    <dt>Affected (Other): </dt>
-                    <dd>{n(get(data, 'other_num_affected'))}</dd>
-                    <dt>Assisted (Other): </dt>
-                    <dd>{n(get(data, 'other_num_assisted'))}</dd>
-                  </dl>
-
-                  <dl className='dl-horizontal numeric-list'>
-                    <dt>Local Staff: </dt>
-                    <dd>{n(get(data, 'num_localstaff'))}</dd>
-                    <dt>Volunteers: </dt>
-                    <dd>{n(get(data, 'num_volunteers'))}</dd>
-                    <dt>Expats/Delegates: </dt>
-                    <dd>{n(get(data, 'num_expats_delegates'))}</dd>
-                  </dl>
-                </DisplaySection>
+                {this.renderNumericDetails(data)}
                 {this.renderPlannedResponse(data)}
                 <DisplaySection title='Description' inner={get(data, 'description', false)} />
                 {this.renderActionsTaken(data, 'NTLS', 'National Society')}

--- a/app/assets/scripts/views/field-report.js
+++ b/app/assets/scripts/views/field-report.js
@@ -231,14 +231,14 @@ class FieldReport extends React.Component {
           <dd>{n(get(data, 'num_assisted'))}</dd>
         </dl>
       </React.Fragment>
-    )
+    );
     return (
       <React.Fragment>
         <DisplaySection title='Numeric details'>
           { status === 'EVT' ? evtHtml : ewHtml }
         </DisplaySection>
         <DisplaySection
-          title='Other Sources'
+          title='Sources for data marked as Other'
           inner={get(data, 'other_sources', false)}
         />
       </React.Fragment>

--- a/app/assets/scripts/views/field-report.js
+++ b/app/assets/scripts/views/field-report.js
@@ -190,6 +190,21 @@ class FieldReport extends React.Component {
                     <dd>{n(get(data, 'gov_num_assisted'))}</dd>
                   </dl>
                   <dl className='dl-horizontal numeric-list'>
+                    <dt>Injured (Other): </dt>
+                    <dd>{n(get(data, 'other_num_injured'))}</dd>
+                    <dt>Missing (Other): </dt>
+                    <dd>{n(get(data, 'other_num_missing'))}</dd>
+                    <dt>Dead (Other): </dt>
+                    <dd>{n(get(data, 'other_num_dead'))}</dd>
+                    <dt>Displaced (Other): </dt>
+                    <dd>{n(get(data, 'other_num_displaced'))}</dd>
+                    <dt>Affected (Other): </dt>
+                    <dd>{n(get(data, 'other_num_affected'))}</dd>
+                    <dt>Assisted (Other): </dt>
+                    <dd>{n(get(data, 'other_num_assisted'))}</dd>
+                  </dl>
+
+                  <dl className='dl-horizontal numeric-list'>
                     <dt>Local Staff: </dt>
                     <dd>{n(get(data, 'num_localstaff'))}</dd>
                     <dt>Volunteers: </dt>


### PR DESCRIPTION
Various changes to show all the data from the field report submission on the field report frontend:

 - Fixes #896 
 - Fixes #895 
 - Render numeric details conditionally based on EVT or EW
 - Add `forecast_based_action` to planned response fields
 - Add `other_sources` field to display
