### PR TITLE
minor text changes on field report form

### DIFF
--- a/app/assets/scripts/utils/field-report-constants.js
+++ b/app/assets/scripts/utils/field-report-constants.js
@@ -2,7 +2,7 @@
 import { listToMap } from '@togglecorp/fujs';
 
 export const statusEarlyWarning = {
-  label: 'Early Warning',
+  label: 'Early Warning / Early Action',
   value: '8',
   description: 'First report for this hazard.'
 };

--- a/app/assets/scripts/utils/format.js
+++ b/app/assets/scripts/utils/format.js
@@ -200,3 +200,7 @@ export function intersperse (arr, sep) {
     return xs.concat([sep, x]);
   }, [arr[0]]);
 }
+
+export function yesno (bool) {
+  return bool ? 'Yes' : 'No';
+}

--- a/app/assets/scripts/views/field-report.js
+++ b/app/assets/scripts/views/field-report.js
@@ -248,7 +248,6 @@ class FieldReport extends React.Component {
 
   renderContent () {
     const { data } = this.props.report;
-    console.log('fr data', data);
     if (!this.props.report.fetched || !data) {
       return null;
     }

--- a/app/assets/scripts/views/field-report.js
+++ b/app/assets/scripts/views/field-report.js
@@ -14,7 +14,8 @@ import {
   separateUppercaseWords as separate,
   nope,
   getResponseStatus,
-  intersperse
+  intersperse,
+  yesno
 } from '../utils/format';
 import { get } from '../utils/utils/';
 
@@ -192,7 +193,7 @@ class FieldReport extends React.Component {
           <dd>{n(get(data, 'num_localstaff'))}</dd>
           <dt>Volunteers: </dt>
           <dd>{n(get(data, 'num_volunteers'))}</dd>
-          <dt>Expats/Delegates: </dt>
+          <dt>Delegates: </dt>
           <dd>{n(get(data, 'num_expats_delegates'))}</dd>
         </dl>
       </React.Fragment>
@@ -247,6 +248,7 @@ class FieldReport extends React.Component {
 
   renderContent () {
     const { data } = this.props.report;
+    console.log('fr data', data);
     if (!this.props.report.fetched || !data) {
       return null;
     }
@@ -281,6 +283,16 @@ class FieldReport extends React.Component {
                 {this.renderNumericDetails(data)}
                 {this.renderPlannedResponse(data)}
                 <DisplaySection title='Description' inner={get(data, 'description', false)} />
+                <DisplaySection title='Requests for Assistance'>
+                  <p>
+                    <span>Government Requests International Assistance: </span>
+                    <span>{yesno(get(data, 'request_assistance'))}</span>
+                  </p>
+                  <p>
+                    <span>NS Requests International Assistance:</span>
+                    <span>{yesno(get(data, 'ns_request_assistance'))}</span>
+                  </p>
+                </DisplaySection>
                 {this.renderActionsTaken(data, 'NTLS', 'National Society')}
                 {this.renderActionsTaken(data, 'FDRN', 'IFRC')}
                 {this.renderActionsTaken(data, 'PNS', 'any other RCRC Movement actors') /* instead of PNS Red Cross, go-frontend/issues/822 */ }


### PR DESCRIPTION
Implements:

 - Change `Early Warning` to `Early Warning / Early Action` in field report form
 - Change `Expats / Delegates` to `Delegates`
 - Add `Requests for Assistance` to field report frontend

cc @mmusori 