### PR TITLE
Field Report changes + bugfix

### DIFF
--- a/app/assets/scripts/views/field-report-form/index.js
+++ b/app/assets/scripts/views/field-report-form/index.js
@@ -630,8 +630,9 @@ class FieldReportForm extends React.Component {
     const plannedResponseRows = fields.plannedResponseRows.filter(row => {
       return !!row.label[status];
     });
+    const responseTitle = status === 'EVT' ? 'Planned Response' : 'Planned Interventions';
     return (
-      <Fold title='Planned Response'>
+      <Fold title={responseTitle}>
         <label className='form__label'>Planned International Response</label>
         <div className='form__description'>
           <p>Indicate status of global and regional tools.</p>

--- a/app/assets/scripts/views/field-report.js
+++ b/app/assets/scripts/views/field-report.js
@@ -135,11 +135,11 @@ class FieldReport extends React.Component {
   getStatus () {
     const { data } = this.props.report;
     const status = data.status;
-    if (status === '8') {
-      return 'EVT';
-    }
-    if (status === '9') {
+    if (status === 8) {
       return 'EW';
+    }
+    if (status === 9) {
+      return 'EVT';
     }
     return 'EVT';
   }
@@ -207,7 +207,7 @@ class FieldReport extends React.Component {
           <dt>People at Highest Risk (RC): </dt>
           <dd>{n(get(data, 'num_highest_risk'))}</dd>
           <dt>Affected Pop Centres (RC): </dt>
-          <dd>{get(data, 'affected_pop_centres')}</dd>
+          <dd>{get(data, 'affected_pop_centres') || '--'}</dd>
         </dl>
         <dl className='dl-horizontal numeric-list'>
           <dt>Potentially Affected (Government): </dt>
@@ -215,7 +215,7 @@ class FieldReport extends React.Component {
           <dt>People at Highest Risk (Government): </dt>
           <dd>{n(get(data, 'gov_num_highest_risk'))}</dd>
           <dt>Affected Pop Centres (Government): </dt>
-          <dd>{get(data, 'gov_affected_pop_centres')}</dd>
+          <dd>{get(data, 'gov_affected_pop_centres') || '--'}</dd>
         </dl>
         <dl className='dl-horizontal numeric-list'>
           <dt>Potentially Affected (Other): </dt>
@@ -223,7 +223,7 @@ class FieldReport extends React.Component {
           <dt>People at Highest Risk (Other): </dt>
           <dd>{n(get(data, 'other_num_highest_risk'))}</dd>
           <dt>Affected Pop Centres (Other): </dt>
-          <dd>{get(data, 'other_affected_pop_centres')}</dd>
+          <dd>{get(data, 'other_affected_pop_centres') || '--'}</dd>
         </dl>
         <dl className='dl-horizontal numeric-list'>
           <dt>Assisted by Government:</dt>


### PR DESCRIPTION
 - Change `Planned Response` to `Planned Interventions` for EW reports.
 - Fix bug of not showing EW specific numeric data on EW field report frontend
 - Handle showing `--` if no pop centre exists

cc @mmusori 