### PR TITLE
Fix/815-console errors

### DIFF
--- a/app/assets/scripts/components/common/filters/date-filter-header.js
+++ b/app/assets/scripts/components/common/filters/date-filter-header.js
@@ -97,7 +97,7 @@ if (environment !== 'production') {
   DateFilterHeader.propTypes = {
     id: T.string,
     title: T.string,
-    filter: T.oneOfType([T.string, T.number]),
+    filter: T.oneOfType([T.string, T.object]),
     onSelect: T.func,
     featureType: T.string
   };

--- a/app/assets/scripts/components/common/filters/date-filter-header.js
+++ b/app/assets/scripts/components/common/filters/date-filter-header.js
@@ -17,6 +17,7 @@ export default class DateFilterHeader extends React.PureComponent {
     this.resetDateStatus = this.resetDateStatus.bind(this);
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillMount () {
     this.setState({
       startDate: this.props.filter.startDate,

--- a/app/assets/scripts/components/common/filters/date-filter-header.js
+++ b/app/assets/scripts/components/common/filters/date-filter-header.js
@@ -17,7 +17,7 @@ export default class DateFilterHeader extends React.PureComponent {
     this.resetDateStatus = this.resetDateStatus.bind(this);
   }
 
-  componentWillMount () {
+  UNSAFE_componentWillMount () {
     this.setState({
       startDate: this.props.filter.startDate,
       endDate: this.props.filter.endDate

--- a/app/assets/scripts/components/connected/alerts-table.js
+++ b/app/assets/scripts/components/connected/alerts-table.js
@@ -72,7 +72,7 @@ class AlertsTable extends SFPComponent {
     this.requestResults(this.props);
   }
 
-  componentWillReceiveProps (newProps) {
+  UNSAFE_componentWillReceiveProps (newProps) {
     if (newProps.limit !== this.props.limit) {
       this.requestResults(newProps);
     }

--- a/app/assets/scripts/components/connected/alerts-table.js
+++ b/app/assets/scripts/components/connected/alerts-table.js
@@ -72,6 +72,7 @@ class AlertsTable extends SFPComponent {
     this.requestResults(this.props);
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps (newProps) {
     if (newProps.limit !== this.props.limit) {
       this.requestResults(newProps);

--- a/app/assets/scripts/components/connected/appeals-table.js
+++ b/app/assets/scripts/components/connected/appeals-table.js
@@ -50,6 +50,7 @@ class AppealsTable extends SFPComponent {
     this.props._getAppealsList();
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps (newProps) {
     let shouldMakeNewRequest = false;
     ['limit', 'country', 'region', 'atype', 'record'].forEach(prop => {

--- a/app/assets/scripts/components/connected/appeals-table.js
+++ b/app/assets/scripts/components/connected/appeals-table.js
@@ -50,7 +50,7 @@ class AppealsTable extends SFPComponent {
     this.props._getAppealsList();
   }
 
-  componentWillReceiveProps (newProps) {
+  UNSAFE_componentWillReceiveProps (newProps) {
     let shouldMakeNewRequest = false;
     ['limit', 'country', 'region', 'atype', 'record'].forEach(prop => {
       if (newProps[prop] !== this.props[prop]) {

--- a/app/assets/scripts/components/connected/appeals-table.js
+++ b/app/assets/scripts/components/connected/appeals-table.js
@@ -290,7 +290,7 @@ if (environment !== 'production') {
 
     limit: T.number,
     country: T.number,
-    region: T.number,
+    region: T.string,
     atype: T.string,
     record: T.string,
 

--- a/app/assets/scripts/components/connected/appeals-table.js
+++ b/app/assets/scripts/components/connected/appeals-table.js
@@ -285,7 +285,7 @@ if (environment !== 'production') {
   AppealsTable.propTypes = {
     _getAppeals: T.func,
     appeals: T.object,
-    appealsList: T.func,
+    appealsList: T.object,
 
     limit: T.number,
     country: T.number,

--- a/app/assets/scripts/components/connected/emergencies-table.js
+++ b/app/assets/scripts/components/connected/emergencies-table.js
@@ -55,7 +55,7 @@ class EmergenciesTable extends SFPComponent {
     this.requestResults(this.props);
   }
 
-  componentWillReceiveProps (newProps) {
+  UNSAFE_componentWillReceiveProps (newProps) {
     let shouldMakeNewRequest = false;
     ['limit', 'country', 'region'].forEach(prop => {
       if (newProps[prop] !== this.props[prop]) {

--- a/app/assets/scripts/components/connected/emergencies-table.js
+++ b/app/assets/scripts/components/connected/emergencies-table.js
@@ -55,6 +55,7 @@ class EmergenciesTable extends SFPComponent {
     this.requestResults(this.props);
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps (newProps) {
     let shouldMakeNewRequest = false;
     ['limit', 'country', 'region'].forEach(prop => {
@@ -226,8 +227,8 @@ if (environment !== 'production') {
     list: T.object,
 
     limit: T.number,
-    country: T.number,
-    region: T.number,
+    country: T.string,
+    region: T.string,
 
     noPaginate: T.bool,
     showExport: T.bool,

--- a/app/assets/scripts/components/connected/eru-table.js
+++ b/app/assets/scripts/components/connected/eru-table.js
@@ -42,6 +42,7 @@ class EruTable extends SFPComponent {
     this.requestResults(this.props);
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps (newProps) {
     let shouldMakeNewRequest = false;
     ['limit', 'emergency'].forEach(prop => {

--- a/app/assets/scripts/components/connected/eru-table.js
+++ b/app/assets/scripts/components/connected/eru-table.js
@@ -42,7 +42,7 @@ class EruTable extends SFPComponent {
     this.requestResults(this.props);
   }
 
-  componentWillReceiveProps (newProps) {
+  UNSAFE_componentWillReceiveProps (newProps) {
     let shouldMakeNewRequest = false;
     ['limit', 'emergency'].forEach(prop => {
       if (newProps[prop] !== this.props[prop]) {

--- a/app/assets/scripts/components/connected/field-reports-table.js
+++ b/app/assets/scripts/components/connected/field-reports-table.js
@@ -50,6 +50,7 @@ class FieldReportsTable extends SFPComponent {
     this.requestResults(this.props);
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps (newProps) {
     let shouldMakeNewRequest = false;
     ['limit', 'country', 'region'].forEach(prop => {

--- a/app/assets/scripts/components/connected/field-reports-table.js
+++ b/app/assets/scripts/components/connected/field-reports-table.js
@@ -50,7 +50,7 @@ class FieldReportsTable extends SFPComponent {
     this.requestResults(this.props);
   }
 
-  componentWillReceiveProps (newProps) {
+  UNSAFE_componentWillReceiveProps (newProps) {
     let shouldMakeNewRequest = false;
     ['limit', 'country', 'region'].forEach(prop => {
       if (newProps[prop] !== this.props[prop]) {

--- a/app/assets/scripts/components/connected/new-password.js
+++ b/app/assets/scripts/components/connected/new-password.js
@@ -41,7 +41,7 @@ class NewPassword extends React.Component {
     this.onSubmit = this.onSubmit.bind(this);
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     if (this.props.password.fetching && !nextProps.password.fetching) {
       hideGlobalLoading();
       if (nextProps.password.error) {

--- a/app/assets/scripts/components/connected/new-password.js
+++ b/app/assets/scripts/components/connected/new-password.js
@@ -41,6 +41,7 @@ class NewPassword extends React.Component {
     this.onSubmit = this.onSubmit.bind(this);
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps (nextProps) {
     if (this.props.password.fetching && !nextProps.password.fetching) {
       hideGlobalLoading();

--- a/app/assets/scripts/components/connected/personnel-table.js
+++ b/app/assets/scripts/components/connected/personnel-table.js
@@ -56,7 +56,7 @@ class PersonnelTable extends SFPComponent {
     this.requestResults(this.props);
   }
 
-  componentWillReceiveProps (newProps) {
+  UNSAFE_componentWillReceiveProps (newProps) {
     let shouldMakeNewRequest = false;
     ['limit', 'emergency'].forEach(prop => {
       if (newProps[prop] !== this.props[prop]) {

--- a/app/assets/scripts/components/connected/personnel-table.js
+++ b/app/assets/scripts/components/connected/personnel-table.js
@@ -56,6 +56,7 @@ class PersonnelTable extends SFPComponent {
     this.requestResults(this.props);
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps (newProps) {
     let shouldMakeNewRequest = false;
     ['limit', 'emergency'].forEach(prop => {
@@ -152,7 +153,7 @@ class PersonnelTable extends SFPComponent {
       },
       {
         id: 'emer',
-        label: <SortHeader id='emer' title='Emergency' sort={this.state.table.sort} onClick={''} /> // for filtering options check .../api/v2/personnel/?limit=2 - the Filters button, Ordering
+        label: <SortHeader id='emer' title='Emergency' sort={this.state.table.sort} onClick={() => {}} /> // for filtering options check .../api/v2/personnel/?limit=2 - the Filters button, Ordering
       }];
 
       const rows = data.results.map(o => ({

--- a/app/assets/scripts/components/connected/user-menu.js
+++ b/app/assets/scripts/components/connected/user-menu.js
@@ -4,34 +4,12 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { PropTypes as T } from 'prop-types';
 import { Link, withRouter } from 'react-router-dom';
+import { isMobileOnly } from 'react-device-detect';
 import { environment } from '../../config';
 import { logoutUser } from '../../actions';
 import Dropdown from '../common/dropdown';
 
 class UserMenu extends React.Component {
-  constructor () {
-    super();
-    this.state = {
-      width: window.innerWidth
-    };
-  }
-
-  // Adds a listener for window size to determine style for menu content
-  // eslint-disable-next-line camelcase
-  UNSAFE_componentWillMount () {
-    window.addEventListener('resize', this.handleWindowSizeChange.bind(this));
-  }
-
-  // Ensures the listener is removed when the component is no longer mounted
-  componentWillUnmount () {
-    window.removeEventListener('resize', this.handleWindowSizeChange.bind(this));
-  }
-
-  // Updates window width change
-  handleWindowSizeChange () {
-    this.setState({ width: window.innerWidth });
-  }
-
   onLogoutClick (e) {
     e.preventDefault();
     this.props._logoutUser();
@@ -39,11 +17,8 @@ class UserMenu extends React.Component {
   }
 
   render () {
-    const { width } = this.state;
-    const isMobile = width <= 767;
-
     // Displays dropdown menu on non-mobile screens and a single logout button for the mobile menu
-    if (this.props.userData.username && !isMobile) {
+    if (this.props.userData.username && !isMobileOnly) {
       return (
         <Dropdown
           id='user-menu'
@@ -62,7 +37,7 @@ class UserMenu extends React.Component {
           </ul>
         </Dropdown>
       );
-    } else if (this.props.userData.username && isMobile) {
+    } else if (this.props.userData.username && isMobileOnly) {
       return (
         <ul className='drop__menu' role='menu'>
           <li><a href='#' title='Logout' className='drop__menu-item' data-hook='dropdown:close' onClick={this.onLogoutClick.bind(this)}>Logout</a></li>

--- a/app/assets/scripts/components/connected/user-menu.js
+++ b/app/assets/scripts/components/connected/user-menu.js
@@ -17,6 +17,7 @@ class UserMenu extends React.Component {
   }
 
   // Adds a listener for window size to determine style for menu content
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillMount () {
     window.addEventListener('resize', this.handleWindowSizeChange.bind(this));
   }

--- a/app/assets/scripts/components/connected/user-menu.js
+++ b/app/assets/scripts/components/connected/user-menu.js
@@ -17,7 +17,7 @@ class UserMenu extends React.Component {
   }
 
   // Adds a listener for window size to determine style for menu content
-  componentWillMount () {
+  UNSAFE_componentWillMount () {
     window.addEventListener('resize', this.handleWindowSizeChange.bind(this));
   }
 

--- a/app/assets/scripts/components/country-list.js
+++ b/app/assets/scripts/components/country-list.js
@@ -53,7 +53,7 @@ const CountryList = props => {
       />
       <ul className='region-countries__list'>
         {Object.entries(alphabetizedList).map(([letter, countries]) =>
-          <div>
+          <div key={letter}>
             <li className='region-countries__letter' key={letter}>{letter}</li>
             <ul>
               {countries.map(country =>

--- a/app/assets/scripts/components/country/preparedness-work-plan.js
+++ b/app/assets/scripts/components/country/preparedness-work-plan.js
@@ -38,6 +38,7 @@ class PreparednessWorkPlan extends React.Component {
     this.lastPayload = {};
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps (nextProps) {
     if (this.props.sendPerWorkplan.receivedAt !== nextProps.sendPerWorkplan.receivedAt) {
       if (typeof nextProps.sendPerWorkplan.data.status !== 'undefined' && nextProps.sendPerWorkplan.data.status !== null) {

--- a/app/assets/scripts/components/country/preparedness-work-plan.js
+++ b/app/assets/scripts/components/country/preparedness-work-plan.js
@@ -38,7 +38,7 @@ class PreparednessWorkPlan extends React.Component {
     this.lastPayload = {};
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     if (this.props.sendPerWorkplan.receivedAt !== nextProps.sendPerWorkplan.receivedAt) {
       if (typeof nextProps.sendPerWorkplan.data.status !== 'undefined' && nextProps.sendPerWorkplan.data.status !== null) {
         this.props._addNewWorkPlan({type: 'ADD_NES_PER_WORK_PLAN', workplan: this.lastPayload});

--- a/app/assets/scripts/components/export-button-container.js
+++ b/app/assets/scripts/components/export-button-container.js
@@ -61,6 +61,7 @@ class ExportButton extends React.Component {
     return filename + postfix + extension;
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps (newProps) {
     if (this.props.csv.fetching && !newProps.csv.fetching && !newProps.csv.error) {
       let firstNewLine = newProps.csv.data.indexOf('\n');

--- a/app/assets/scripts/components/export-button-container.js
+++ b/app/assets/scripts/components/export-button-container.js
@@ -61,7 +61,7 @@ class ExportButton extends React.Component {
     return filename + postfix + extension;
   }
 
-  componentWillReceiveProps (newProps) {
+  UNSAFE_componentWillReceiveProps (newProps) {
     if (this.props.csv.fetching && !newProps.csv.fetching && !newProps.csv.error) {
       let firstNewLine = newProps.csv.data.indexOf('\n');
       let firstRow = this.replaceColumnNames(newProps.csv.data);

--- a/app/assets/scripts/components/fold.js
+++ b/app/assets/scripts/components/fold.js
@@ -72,7 +72,7 @@ if (environment !== 'production') {
     title: T.string,
     navLink: T.element,
     foldClass: T.string,
-    extraClass: T.bool,
+    extraClass: T.oneOfType([T.string, T.bool]),
     description: T.string,
     showHeader: T.bool,
     header: T.oneOfType([T.element, T.func]),

--- a/app/assets/scripts/components/highlighted-operations/index.js
+++ b/app/assets/scripts/components/highlighted-operations/index.js
@@ -89,6 +89,7 @@ class HighlightedOperations extends React.Component {
           <div className={listStyle}>
             {operations.slice(0, 6).map(operation =>
               <OperationCard
+                key={operation}
                 operation={operation}
                 calculateDeployedPersonnel={this.calculateDeployedPersonnel}
               />

--- a/app/assets/scripts/components/highlighted-operations/index.js
+++ b/app/assets/scripts/components/highlighted-operations/index.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { PropTypes as T } from 'prop-types';
 import { Link } from 'react-router-dom';
 import { environment } from '../../config';
+import { get } from '../../utils/utils';
 import { getFeaturedEmergencies, getFeaturedEmergenciesForRegion, getFeaturedEmergenciesDeployments, getDeploymentERU } from '../../actions';
 import BlockLoading from '../block-loading';
 import Fold from '../fold';
@@ -89,9 +90,12 @@ class HighlightedOperations extends React.Component {
           <div className={listStyle}>
             {operations.slice(0, 6).map(operation =>
               <OperationCard
-                key={operation}
-                operation={operation}
-                calculateDeployedPersonnel={this.calculateDeployedPersonnel}
+                key={operation.id}
+                operationId={operation.id}
+                operationName={operation.name}
+                emergencyDeployments={this.calculateDeployedPersonnel(operation)}
+                appeals={get(operation, 'appeals', [])}
+                lastUpdate={operation.updated_at}
               />
             )}
           </div>

--- a/app/assets/scripts/components/highlighted-operations/index.js
+++ b/app/assets/scripts/components/highlighted-operations/index.js
@@ -116,7 +116,7 @@ if (environment !== 'production') {
     deployments: T.object,
     eru: T.object,
     opsType: T.string,
-    opsId: T.string
+    opsId: T.number
   };
 }
 

--- a/app/assets/scripts/components/highlighted-operations/operation-card.js
+++ b/app/assets/scripts/components/highlighted-operations/operation-card.js
@@ -59,7 +59,7 @@ export default OperationCard;
 
 if (environment !== 'production') {
   OperationCard.propTypes = {
-    operationId: PropTypes.number,
+    operationId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     operationName: PropTypes.string,
     emergencyDeployments: PropTypes.shape({
       deployedErus: PropTypes.number,

--- a/app/assets/scripts/components/highlighted-operations/operation-card.js
+++ b/app/assets/scripts/components/highlighted-operations/operation-card.js
@@ -1,25 +1,21 @@
 import React from 'react';
-import { get } from '../../utils/utils';
 import { Link } from 'react-router-dom';
 import { environment } from '../../config';
 import { PropTypes } from 'prop-types';
 import { formatDate, percent, round, commaSeparatedNumber as n } from '../../utils/format';
 import Progress from './../progress-labeled';
 
-const OperationCard = ({operation, calculateDeployedPersonnel}) => {
-  const { id, name } = operation;
-  const appeals = get(operation, 'appeals', []);
+const OperationCard = ({operationId, operationName, emergencyDeployments, appeals, lastUpdate}) => {
   const beneficiaries = appeals.reduce((acc, curr) => acc + curr.num_beneficiaries, 0);
   const requested = appeals.reduce((acc, curr) => acc + Number(curr.amount_requested), 0);
   const funded = appeals.reduce((acc, curr) => acc + Number(curr.amount_funded), 0);
-  const emergencyDeployments = calculateDeployedPersonnel(operation);
 
   return (
-    <div className='key-emergencies-item' key={id}>
-      <Link to={`/emergencies/${id}`}>
+    <div className='key-emergencies-item' key={operationId}>
+      <Link to={`/emergencies/${operationId}`}>
         <div className="card_box card_box_left">
-          <h2 className='card__title'>{ name.length > 30 ? name.slice(0, 30) + '...' : name }</h2>
-          <small className='last_updated'>Last updated: {formatDate(operation.updated_at)}</small>
+          <h2 className='card__title'>{ operationName.length > 30 ? operationName.slice(0, 30) + '...' : operationName }</h2>
+          <small className='last_updated'>Last updated: {formatDate(lastUpdate)}</small>
         </div>
 
         <div className='card_box_container card_box_container--op'>
@@ -63,7 +59,14 @@ export default OperationCard;
 
 if (environment !== 'production') {
   OperationCard.propTypes = {
-    operation: PropTypes.object,
-    calculateDeployedPersonnel: PropTypes.func
+    operationId: PropTypes.string,
+    operationName: PropTypes.string,
+    emergencyDeployments: PropTypes.shape({
+      deployedErus: PropTypes.number,
+      deployedPersonnel: PropTypes.number,
+    }),
+    lastUpdate: PropTypes.string,
+    appeals: PropTypes.array,
+
   };
 }

--- a/app/assets/scripts/components/highlighted-operations/operation-card.js
+++ b/app/assets/scripts/components/highlighted-operations/operation-card.js
@@ -59,7 +59,7 @@ export default OperationCard;
 
 if (environment !== 'production') {
   OperationCard.propTypes = {
-    operationId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    operationId: PropTypes.number,
     operationName: PropTypes.string,
     emergencyDeployments: PropTypes.shape({
       deployedErus: PropTypes.number,

--- a/app/assets/scripts/components/highlighted-operations/operation-card.js
+++ b/app/assets/scripts/components/highlighted-operations/operation-card.js
@@ -59,7 +59,7 @@ export default OperationCard;
 
 if (environment !== 'production') {
   OperationCard.propTypes = {
-    operationId: PropTypes.string,
+    operationId: PropTypes.number,
     operationName: PropTypes.string,
     emergencyDeployments: PropTypes.shape({
       deployedErus: PropTypes.number,

--- a/app/assets/scripts/components/map/common/map-component.js
+++ b/app/assets/scripts/components/map/common/map-component.js
@@ -65,6 +65,7 @@ export default class MapComponent extends React.Component {
     }
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps (nextProps) {
     // Short-circuit any map-changing actions if the map hasn't finished loading.
     if (!this.mapLoaded) return;

--- a/app/assets/scripts/components/map/common/map-component.js
+++ b/app/assets/scripts/components/map/common/map-component.js
@@ -65,7 +65,7 @@ export default class MapComponent extends React.Component {
     }
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     // Short-circuit any map-changing actions if the map hasn't finished loading.
     if (!this.mapLoaded) return;
 

--- a/app/assets/scripts/components/map/country-map.js
+++ b/app/assets/scripts/components/map/country-map.js
@@ -56,6 +56,7 @@ class CountryMap extends React.Component {
     }
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps ({ operations, deployments }) {
     if (operations && !this.props.operations.fetched && operations.fetched && !operations.error) {
       this.setMarkerLayers(operations);

--- a/app/assets/scripts/components/map/country-map.js
+++ b/app/assets/scripts/components/map/country-map.js
@@ -56,7 +56,7 @@ class CountryMap extends React.Component {
     }
   }
 
-  componentWillReceiveProps ({ operations, deployments }) {
+  UNSAFE_componentWillReceiveProps ({ operations, deployments }) {
     if (operations && !this.props.operations.fetched && operations.fetched && !operations.error) {
       this.setMarkerLayers(operations);
     }

--- a/app/assets/scripts/components/map/deployments-map.js
+++ b/app/assets/scripts/components/map/deployments-map.js
@@ -33,7 +33,7 @@ export default class DeploymentsMap extends React.Component {
     this.configureMap = this.configureMap.bind(this);
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     if (this.props.data !== nextProps.data) {
       this.setState({
         layers: this.getLayers(nextProps.data.features)

--- a/app/assets/scripts/components/map/deployments-map.js
+++ b/app/assets/scripts/components/map/deployments-map.js
@@ -33,6 +33,7 @@ export default class DeploymentsMap extends React.Component {
     this.configureMap = this.configureMap.bind(this);
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps (nextProps) {
     if (this.props.data !== nextProps.data) {
       this.setState({

--- a/app/assets/scripts/components/map/emergencies-map.js
+++ b/app/assets/scripts/components/map/emergencies-map.js
@@ -27,6 +27,7 @@ class EmergenciesMap extends React.Component {
     this.navigate = this.navigate.bind(this);
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps ({lastMonth}) {
     if (!this.props.lastMonth.fetched && lastMonth.fetched && !lastMonth.error) {
       this.setState({

--- a/app/assets/scripts/components/map/emergencies-map.js
+++ b/app/assets/scripts/components/map/emergencies-map.js
@@ -27,7 +27,7 @@ class EmergenciesMap extends React.Component {
     this.navigate = this.navigate.bind(this);
   }
 
-  componentWillReceiveProps ({lastMonth}) {
+  UNSAFE_componentWillReceiveProps ({lastMonth}) {
     if (!this.props.lastMonth.fetched && lastMonth.fetched && !lastMonth.error) {
       this.setState({
         layers: this.getLayers(lastMonth.data.geoJSON, this.state.scaleBy)

--- a/app/assets/scripts/components/map/main-map.js
+++ b/app/assets/scripts/components/map/main-map.js
@@ -62,6 +62,7 @@ class MainMap extends React.Component {
     }
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps ({ operations, deployments }) {
     if (operations && !this.props.operations.fetched && operations.fetched && !operations.error) {
       this.setMarkerLayers(operations);

--- a/app/assets/scripts/components/map/main-map.js
+++ b/app/assets/scripts/components/map/main-map.js
@@ -62,7 +62,7 @@ class MainMap extends React.Component {
     }
   }
 
-  componentWillReceiveProps ({ operations, deployments }) {
+  UNSAFE_componentWillReceiveProps ({ operations, deployments }) {
     if (operations && !this.props.operations.fetched && operations.fetched && !operations.error) {
       this.setMarkerLayers(operations);
     }

--- a/app/assets/scripts/components/map/per-map.js
+++ b/app/assets/scripts/components/map/per-map.js
@@ -57,7 +57,7 @@ class PerMap extends React.Component {
     }
   }
 
-  componentWillReceiveProps ({ data }) {
+  UNSAFE_componentWillReceiveProps ({ data }) {
     if (data && !this.props.data.fetched && data.fetched && !data.error) {
       this.setMarkerLayers(data);
     }

--- a/app/assets/scripts/components/map/per-map.js
+++ b/app/assets/scripts/components/map/per-map.js
@@ -57,6 +57,7 @@ class PerMap extends React.Component {
     }
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps ({ data }) {
     if (data && !this.props.data.fetched && data.fetched && !data.error) {
       this.setMarkerLayers(data);

--- a/app/assets/scripts/components/per-forms/overview-form.js
+++ b/app/assets/scripts/components/per-forms/overview-form.js
@@ -55,7 +55,7 @@ class OverviewForm extends React.Component {
     }
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     if (this.props.getPerDraftDocument.fetched !== nextProps.getPerDraftDocument.fetched && nextProps.getPerDraftDocument.data.count === 1) {
       this.loadedDraft = JSON.parse(nextProps.getPerDraftDocument.data.results[0].data.replace(/'/g, '"'));
     }

--- a/app/assets/scripts/components/per-forms/overview-form.js
+++ b/app/assets/scripts/components/per-forms/overview-form.js
@@ -55,6 +55,7 @@ class OverviewForm extends React.Component {
     }
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps (nextProps) {
     if (this.props.getPerDraftDocument.fetched !== nextProps.getPerDraftDocument.fetched && nextProps.getPerDraftDocument.data.count === 1) {
       this.loadedDraft = JSON.parse(nextProps.getPerDraftDocument.data.results[0].data.replace(/'/g, '"'));

--- a/app/assets/scripts/components/timeline-charts.js
+++ b/app/assets/scripts/components/timeline-charts.js
@@ -73,7 +73,7 @@ class TimelineCharts extends React.Component {
           <Line name='Appeals' type='monotone' dataKey='appeals.count' stroke='#C02C2C' />
           <Line name='DREFs' type='monotone' dataKey='drefs.count' stroke='#F39C12' />
           <Tooltip content={contentFormatter}/>
-          <Legend verticalAlign='bottom' iconType='circle' iconSize='10' />
+          <Legend verticalAlign='bottom' iconType='circle' iconSize={10} />
         </LineChart>
       </ResponsiveContainer>
     );

--- a/app/assets/scripts/components/timeline-charts.js
+++ b/app/assets/scripts/components/timeline-charts.js
@@ -209,7 +209,7 @@ if (environment !== 'production') {
   TimelineCharts.propTypes = {
     _getAggregateAppeals: T.func,
     aggregate: T.object,
-    region: T.string
+    region: T.number
   };
 }
 // /////////////////////////////////////////////////////////////////// //

--- a/app/assets/scripts/views/CountryOverview/Map.js
+++ b/app/assets/scripts/views/CountryOverview/Map.js
@@ -25,7 +25,7 @@ export default class ThreeWMap extends React.PureComponent {
     this.map.on('load', this.handleMapLoad);
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     const {
       countryId: oldCountryId,
       districtList: oldDistrictList,

--- a/app/assets/scripts/views/CountryOverview/Map.js
+++ b/app/assets/scripts/views/CountryOverview/Map.js
@@ -25,6 +25,7 @@ export default class ThreeWMap extends React.PureComponent {
     this.map.on('load', this.handleMapLoad);
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps (nextProps) {
     const {
       countryId: oldCountryId,

--- a/app/assets/scripts/views/ThreeW/map.js
+++ b/app/assets/scripts/views/ThreeW/map.js
@@ -100,7 +100,7 @@ export default class ThreeWMap extends React.PureComponent {
     this.map.on('click', this.handleMapClick);
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     const {
       countryId: oldCountryId,
       projectList: oldProjectList,

--- a/app/assets/scripts/views/ThreeW/map.js
+++ b/app/assets/scripts/views/ThreeW/map.js
@@ -100,6 +100,7 @@ export default class ThreeWMap extends React.PureComponent {
     this.map.on('click', this.handleMapClick);
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps (nextProps) {
     const {
       countryId: oldCountryId,

--- a/app/assets/scripts/views/account.js
+++ b/app/assets/scripts/views/account.js
@@ -231,6 +231,7 @@ class Account extends React.Component {
     }
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps (nextProps) {
     if (this.props.profile.receivedAt !== nextProps.profile.receivedAt) {
       if (typeof nextProps.profile.data !== 'undefined' && nextProps.profile.data !== null && typeof nextProps.profile.data.subscription !== 'undefined' && nextProps.profile.data.subscription !== null) {

--- a/app/assets/scripts/views/account.js
+++ b/app/assets/scripts/views/account.js
@@ -231,7 +231,7 @@ class Account extends React.Component {
     }
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     if (this.props.profile.receivedAt !== nextProps.profile.receivedAt) {
       if (typeof nextProps.profile.data !== 'undefined' && nextProps.profile.data !== null && typeof nextProps.profile.data.subscription !== 'undefined' && nextProps.profile.data.subscription !== null) {
         nextProps.profile.data.subscription.forEach((subscription) => {

--- a/app/assets/scripts/views/countries.js
+++ b/app/assets/scripts/views/countries.js
@@ -138,7 +138,7 @@ class AdminArea extends SFPComponent {
     this.threeWFilters = {};
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     if (getCountryId(this.props.match.params.id) !== getCountryId(nextProps.match.params.id)) {
       this.getData(nextProps);
       return this.getAdmArea(nextProps.type, getCountryId(nextProps.match.params.id));

--- a/app/assets/scripts/views/countries.js
+++ b/app/assets/scripts/views/countries.js
@@ -138,6 +138,7 @@ class AdminArea extends SFPComponent {
     this.threeWFilters = {};
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps (nextProps) {
     if (getCountryId(this.props.match.params.id) !== getCountryId(nextProps.match.params.id)) {
       this.getData(nextProps);

--- a/app/assets/scripts/views/deployments.js
+++ b/app/assets/scripts/views/deployments.js
@@ -60,6 +60,7 @@ class Deployments extends SFPComponent {
     this.props._getActivePersonnel();
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps (nextProps) {
     if (finishedFetch(this.props, nextProps, 'eruOwners')) {
       hideGlobalLoading();

--- a/app/assets/scripts/views/deployments.js
+++ b/app/assets/scripts/views/deployments.js
@@ -60,7 +60,7 @@ class Deployments extends SFPComponent {
     this.props._getActivePersonnel();
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     if (finishedFetch(this.props, nextProps, 'eruOwners')) {
       hideGlobalLoading();
     }

--- a/app/assets/scripts/views/emergency.js
+++ b/app/assets/scripts/views/emergency.js
@@ -71,6 +71,7 @@ class Emergency extends React.Component {
     this.isSubscribed = this.isSubscribed.bind(this);
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps (nextProps) {
     if (this.props.location.hash !== nextProps.location.hash) {
       const top = window.pageYOffset !== undefined ? window.pageYOffset : window.scrollTop;

--- a/app/assets/scripts/views/emergency.js
+++ b/app/assets/scripts/views/emergency.js
@@ -71,7 +71,7 @@ class Emergency extends React.Component {
     this.isSubscribed = this.isSubscribed.bind(this);
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     if (this.props.location.hash !== nextProps.location.hash) {
       const top = window.pageYOffset !== undefined ? window.pageYOffset : window.scrollTop;
       window.scrollTo(0, top - 90);

--- a/app/assets/scripts/views/field-report-form/index.js
+++ b/app/assets/scripts/views/field-report-form/index.js
@@ -72,7 +72,7 @@ class FieldReportForm extends React.Component {
     this.onStepBackClick = this.onStepBackClick.bind(this);
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     if (this.props.fieldReportForm.fetching && !nextProps.fieldReportForm.fetching) {
       hideGlobalLoading();
       if (nextProps.fieldReportForm.error) {

--- a/app/assets/scripts/views/field-report-form/index.js
+++ b/app/assets/scripts/views/field-report-form/index.js
@@ -72,6 +72,7 @@ class FieldReportForm extends React.Component {
     this.onStepBackClick = this.onStepBackClick.bind(this);
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps (nextProps) {
     if (this.props.fieldReportForm.fetching && !nextProps.fieldReportForm.fetching) {
       hideGlobalLoading();

--- a/app/assets/scripts/views/field-report.js
+++ b/app/assets/scripts/views/field-report.js
@@ -22,7 +22,7 @@ import { get } from '../utils/utils/';
 import App from './app';
 
 class FieldReport extends React.Component {
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     if (this.props.match.params.id !== nextProps.match.params.id) {
       return this.getReport(nextProps.match.params.id);
     }

--- a/app/assets/scripts/views/field-report.js
+++ b/app/assets/scripts/views/field-report.js
@@ -22,6 +22,7 @@ import { get } from '../utils/utils/';
 import App from './app';
 
 class FieldReport extends React.Component {
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps (nextProps) {
     if (this.props.match.params.id !== nextProps.match.params.id) {
       return this.getReport(nextProps.match.params.id);

--- a/app/assets/scripts/views/login.js
+++ b/app/assets/scripts/views/login.js
@@ -33,6 +33,7 @@ class Login extends React.Component {
     showGlobalLoading();
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps (nextProps) {
     if (this.props.user.fetching && !nextProps.user.fetching) {
       hideGlobalLoading();

--- a/app/assets/scripts/views/login.js
+++ b/app/assets/scripts/views/login.js
@@ -33,7 +33,7 @@ class Login extends React.Component {
     showGlobalLoading();
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     if (this.props.user.fetching && !nextProps.user.fetching) {
       hideGlobalLoading();
       if (!nextProps.user.error) {

--- a/app/assets/scripts/views/preparedness.js
+++ b/app/assets/scripts/views/preparedness.js
@@ -46,7 +46,7 @@ class Preparedness extends React.Component {
     this.props._getPerMission(null);
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     if (nextProps.collaboratingPerCountry.fetched && !this.collaboratingPerCountryBuilt) {
       const geoJson = {
         type: 'FeatureCollection',

--- a/app/assets/scripts/views/preparedness.js
+++ b/app/assets/scripts/views/preparedness.js
@@ -46,6 +46,7 @@ class Preparedness extends React.Component {
     this.props._getPerMission(null);
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps (nextProps) {
     if (nextProps.collaboratingPerCountry.fetched && !this.collaboratingPerCountryBuilt) {
       const geoJson = {

--- a/app/assets/scripts/views/recover-account.js
+++ b/app/assets/scripts/views/recover-account.js
@@ -30,7 +30,7 @@ class RecoverAccount extends React.Component {
     this.onSubmit = this.onSubmit.bind(this);
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     if (this.state.hasTokens) { return; }
     if (this.props.password.fetching && !nextProps.password.fetching) {
       hideGlobalLoading();

--- a/app/assets/scripts/views/recover-account.js
+++ b/app/assets/scripts/views/recover-account.js
@@ -30,6 +30,7 @@ class RecoverAccount extends React.Component {
     this.onSubmit = this.onSubmit.bind(this);
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps (nextProps) {
     if (this.state.hasTokens) { return; }
     if (this.props.password.fetching && !nextProps.password.fetching) {

--- a/app/assets/scripts/views/recover-username.js
+++ b/app/assets/scripts/views/recover-username.js
@@ -26,6 +26,7 @@ class RecoverUsername extends React.Component {
     this.onSubmit = this.onSubmit.bind(this);
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps (nextProps) {
     if (this.props.email.fetching && !nextProps.email.fetching) {
       hideGlobalLoading();

--- a/app/assets/scripts/views/recover-username.js
+++ b/app/assets/scripts/views/recover-username.js
@@ -26,7 +26,7 @@ class RecoverUsername extends React.Component {
     this.onSubmit = this.onSubmit.bind(this);
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     if (this.props.email.fetching && !nextProps.email.fetching) {
       hideGlobalLoading();
       showAlert('success', <p>If the given email address exists here, you will find an email in your mailbox...</p>, true, 3000);

--- a/app/assets/scripts/views/region.js
+++ b/app/assets/scripts/views/region.js
@@ -72,6 +72,7 @@ class AdminArea extends SFPComponent {
     this.onFullscreenChange = this.onFullscreenChange.bind(this);
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps (nextProps) {
     if (getRegionId(this.props.match.params.id) !== getRegionId(nextProps.match.params.id)) {
       this.getData(nextProps);

--- a/app/assets/scripts/views/region.js
+++ b/app/assets/scripts/views/region.js
@@ -72,7 +72,7 @@ class AdminArea extends SFPComponent {
     this.onFullscreenChange = this.onFullscreenChange.bind(this);
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     if (getRegionId(this.props.match.params.id) !== getRegionId(nextProps.match.params.id)) {
       this.getData(nextProps);
       this.setState({ maskLayer: this.getMaskLayer(getRegionId(nextProps.match.params.id)) });

--- a/app/assets/scripts/views/register.js
+++ b/app/assets/scripts/views/register.js
@@ -61,7 +61,7 @@ class Register extends React.Component {
     this.onSubmit = this.onSubmit.bind(this);
   }
 
-  componentWillReceiveProps (nextProps) {
+  UNSAFE_componentWillReceiveProps (nextProps) {
     if (this.props.registration.fetching && !nextProps.registration.fetching) {
       hideGlobalLoading();
       if (nextProps.registration.error) {

--- a/app/assets/scripts/views/register.js
+++ b/app/assets/scripts/views/register.js
@@ -61,6 +61,7 @@ class Register extends React.Component {
     this.onSubmit = this.onSubmit.bind(this);
   }
 
+  // eslint-disable-next-line camelcase
   UNSAFE_componentWillReceiveProps (nextProps) {
     if (this.props.registration.fetching && !nextProps.registration.fetching) {
       hideGlobalLoading();

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     "prop-types": "^15.6.0",
     "qs": "^6.5.1",
     "react": "^16.9.0",
+    "react-device-detect": "^1.11.14",
     "react-dom": "^16.9.0",
     "react-helmet": "^5.2.0",
     "react-markdown": "^3.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8625,6 +8625,13 @@ raw-body@^2.3.2:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+react-device-detect@^1.11.14:
+  version "1.11.14"
+  resolved "https://registry.yarnpkg.com/react-device-detect/-/react-device-detect-1.11.14.tgz#02ba2398e2ce81fb0eaed3e62a9ad713ab3870a7"
+  integrity sha512-WSjch241xI+rXHVtJaSYxNUT2WAykzfJgMI2Hg9xjNNTlIZdJu/fmWf4iedNH7qzFq+JaJ6fDJu3mrKFLerKBw==
+  dependencies:
+    ua-parser-js "^0.7.20"
+
 react-dom@^16.9.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.12.0.tgz#0da4b714b8d13c2038c9396b54a92baea633fe11"
@@ -10826,6 +10833,11 @@ ua-parser-js@0.7.17:
   version "0.7.17"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.17.tgz#e9ec5f9498b9ec910e7ae3ac626a805c4d09ecac"
   integrity sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g==
+
+ua-parser-js@^0.7.20:
+  version "0.7.21"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.21.tgz#853cf9ce93f642f67174273cc34565ae6f308777"
+  integrity sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==
 
 uglify-js@^3.0.5:
   version "3.7.2"


### PR DESCRIPTION
#815
- fixes most of the proptype errors showing in the console
- adds keys to some component lists that were missing them
- removes warnings for deprecated life-cycle methods by running `npx react-codemod rename-unsafe-lifecycles` which adds an `UNSAFE_` prefix to deprecated lifecycles
- replaces manual window sizing for user drop down in favor of [`react-device-detect`](https://www.npmjs.com/package/react-device-detect) this identifies the window size without causing the errors the previous method caused