### PR TITLE
changes layer to display phase

### DIFF
--- a/app/assets/scripts/components/map/per-map.js
+++ b/app/assets/scripts/components/map/per-map.js
@@ -64,9 +64,14 @@ class PerMap extends React.Component {
   }
 
   setMarkerLayers (data) {
+    const geoJSON = data.data.geoJSON;
+    geoJSON.features.map(feature => {
+      feature.properties.phaseCode = feature.properties.phase.phase.toString();
+      return feature;
+    });
     this.setState({
-      markerLayers: this.markerLayerStylesheetFactory.buildMarkerLayers(data.data.geoJSON),
-      markerGeoJSON: data.data.geoJSON
+      markerLayers: this.markerLayerStylesheetFactory.buildMarkerLayers(geoJSON),
+      markerGeoJSON: geoJSON
     });
   }
 

--- a/app/assets/scripts/components/map/per-map/explanation-bubble.js
+++ b/app/assets/scripts/components/map/per-map/explanation-bubble.js
@@ -9,20 +9,20 @@ class ExplanationBubble extends React.Component {
     return (
       <figcaption className='map-vis__legend map-vis__legend--bottom-right legend'>
         <div>
-          <label className='form__label'>Last submitted form</label>
+          <label className='form__label'>Last submitted phase</label>
           <dl className='legend__dl legend__dl--colors'>
-            <dt className='color color--a1-form'>Light blue</dt>
-            <dd>Area 1: Policy and Standards</dd>
-            <dt className='color color--a2-form'>Yellow</dt>
-            <dd>Area 2: Analysis and Planning</dd>
-            <dt className='color color--a3-form'>Grey</dt>
-            <dd>Area 3: Operation capacity</dd>
-            <dt className='color color--a32-form'>Grey</dt>
-            <dd>Area 3: Operational capacity 2</dd>
-            <dt className='color color--a4-form'>Grey</dt>
-            <dd>Area 4: Coordination</dd>
-            <dt className='color color--a5-form'>Grey</dt>
-            <dd>Area 5: Operations support</dd>
+            <dt className='color color--orientation'>Green</dt>ß
+            <dd>Orientation</dd>
+            <dt className='color color--assessment'>Red</dt>
+            <dd>Assessment</dd>
+            <dt className='color color--prioritization'>Blue</dt>
+            <dd>Prioritization & Analysis</dd>
+            <dt className='color color--work'>Purple</dt>
+            <dd>Work Plan</dd>
+            <dt className='color color--action'>Orange</dt>
+            <dd>Action & Accountability</dd>
+            <dt className='color color--grey'>Grey</dt>
+            <dd>Incomplete</dd>
           </dl>
         </div>
       </figcaption>

--- a/app/assets/scripts/components/map/per-map/factory/marker-layer-stylesheet-factory.js
+++ b/app/assets/scripts/components/map/per-map/factory/marker-layer-stylesheet-factory.js
@@ -10,15 +10,15 @@ class MarkerLayerStylesheetFactory {
 
   buildMarkerLayers () {
     const ccolor = {
-      property: 'code',
+      property: 'phaseCode',
       type: 'categorical',
       stops: [
-        ['a1', '#42c5f5'],
-        ['a2', '#2724ff'],
-        ['a3', '#33ff4b'],
-        ['a3-2', '#00a313'],
-        ['a4', '#e3df00'],
-        ['a5', '#e32d00']
+        ['1', '#00845F'],
+        ['2', '#BD001C'],
+        ['3', '#2D5086'],
+        ['4', '#740544'],
+        ['5', '#CC700E'],
+        ['-1', '#CCCCCC']
       ]
     };
     const cradius = this.getCircleRadiusPaintProp();

--- a/app/assets/scripts/views/preparedness.js
+++ b/app/assets/scripts/views/preparedness.js
@@ -54,20 +54,18 @@ class Preparedness extends React.Component {
       };
 
       nextProps.collaboratingPerCountry.data.results.map((perForm) => {
-        if (perForm.country) {
-          let countryMeta = getCountryMeta(perForm.country.id);
-          perForm.country.iso = countryMeta.iso;
-          let countryCentroid = getCentroid(perForm.country.iso);
-          perForm.country.centroid = countryCentroid;
+        let countryMeta = getCountryMeta(perForm.country.id);
+        perForm.country.iso = countryMeta.iso;
+        let countryCentroid = getCentroid(perForm.country.iso);
+        perForm.country.centroid = countryCentroid;
 
-          geoJson.features.push({
-            geometry: {
-              type: 'Point',
-              coordinates: countryCentroid
-            },
-            properties: perForm
-          });
-        }
+        geoJson.features.push({
+          geometry: {
+            type: 'Point',
+            coordinates: countryCentroid
+          },
+          properties: perForm
+        });
 
         return perForm;
       });

--- a/app/assets/scripts/views/preparedness.js
+++ b/app/assets/scripts/views/preparedness.js
@@ -54,18 +54,20 @@ class Preparedness extends React.Component {
       };
 
       nextProps.collaboratingPerCountry.data.results.map((perForm) => {
-        let countryMeta = getCountryMeta(perForm.country.id);
-        perForm.country.iso = countryMeta.iso;
-        let countryCentroid = getCentroid(perForm.country.iso);
-        perForm.country.centroid = countryCentroid;
+        if (perForm.country) {
+          let countryMeta = getCountryMeta(perForm.country.id);
+          perForm.country.iso = countryMeta.iso;
+          let countryCentroid = getCentroid(perForm.country.iso);
+          perForm.country.centroid = countryCentroid;
 
-        geoJson.features.push({
-          geometry: {
-            type: 'Point',
-            coordinates: countryCentroid
-          },
-          properties: perForm
-        });
+          geoJson.features.push({
+            geometry: {
+              type: 'Point',
+              coordinates: countryCentroid
+            },
+            properties: perForm
+          });
+        }
 
         return perForm;
       });

--- a/app/assets/styles/home/_global.scss
+++ b/app/assets/styles/home/_global.scss
@@ -544,28 +544,24 @@
     background: #97acb3;
   }
 
-  .color--a1-form::before {
-    background: #42c5f5;
+  .color--orientation::before {
+    background: #00845F;
   }
 
-  .color--a2-form::before {
-    background: #2724ff;
+  .color--assessment::before {
+    background: #BD001C;
   }
 
-  .color--a3-form::before {
-    background: #33ff4b;
+  .color--prioritization::before {
+    background: #2D5086;
   }
 
-  .color--a32-form::before {
-    background: #00a313;
+  .color--work::before {
+    background: #740544;
   }
 
-  .color--a4-form::before {
-    background: #e3df00;
-  }
-
-  .color--a5-form::before {
-    background: #e32d00;
+  .color--action::before {
+    background: #CC700E;
   }
 }
 


### PR DESCRIPTION
## Description
Changes the map layers to show the phases rather than the section of the form completed. I added a 'incomplete' option which represents any form that has not completed any phase. I don't know if this is a realistic scenario. I know that some of our forms created for testing fall in that category but that might be due to the fact that these forms were not completed as intended. 

I think we should definitely have a fallback color in the case that users do not complete a phase, but I'm not sure if it should be included in the legend

## Related Issue
#844

## Motivation and Context

> The map on the PER page currently shows information on the PER forms that have been completed by a National Society. The request from the PER team has been to have the map instead display the PER phase that the NS has last completed.

## How Has This Been Tested?
 _Please describe in detail how you tested your changes._
_Include details of your testing environment, and the tests you ran to_
_see how your change affects other areas of the code, etc._

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/20410256/73077355-021db180-3e8e-11ea-96a7-38684df53e3c.png)

![image](https://user-images.githubusercontent.com/20410256/73077390-119cfa80-3e8e-11ea-9d1c-a4d6b9ee2533.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
