### PR TITLE
adds error handle for perForm

### DIFF
--- a/app/assets/scripts/views/preparedness.js
+++ b/app/assets/scripts/views/preparedness.js
@@ -54,18 +54,22 @@ class Preparedness extends React.Component {
       };
 
       nextProps.collaboratingPerCountry.data.results.map((perForm) => {
-        let countryMeta = getCountryMeta(perForm.country.id);
-        perForm.country.iso = countryMeta.iso;
-        let countryCentroid = getCentroid(perForm.country.iso);
-        perForm.country.centroid = countryCentroid;
+        if (perForm.country) {
+          let countryMeta = getCountryMeta(perForm.country.id);
+          perForm.country.iso = countryMeta.iso;
+          let countryCentroid = getCentroid(perForm.country.iso);
+          perForm.country.centroid = countryCentroid;
 
-        geoJson.features.push({
-          geometry: {
-            type: 'Point',
-            coordinates: countryCentroid
-          },
-          properties: perForm
-        });
+          geoJson.features.push({
+            geometry: {
+              type: 'Point',
+              coordinates: countryCentroid
+            },
+            properties: perForm
+          });
+        } else {
+          console.error('Country details are missing for perform');
+        }
 
         return perForm;
       });


### PR DESCRIPTION
This adds an error message for missing country details on per form
At one point during testing a form was created without a country. I'm not sure how this happen. Possible causes could be:
- A faulty form was creating during development
- #918 mentions the country dropdown list for PER forms includes national societies that don't exist. It might be possible that the page offers the option to create a form with no country code

This solution does not solve for the creation of a form without a country. 
It prevents the rendering of a form that has no country without breaking any other functionality on the page.

This fix was included in #941 but I'm breaking it out to a separate PR so that we can push it through the approval stage quicker