### PR TITLE
moves variable def inside conditional

### DIFF
--- a/app/assets/scripts/components/per-forms/per-form-component.js
+++ b/app/assets/scripts/components/per-forms/per-form-component.js
@@ -193,8 +193,8 @@ if (environment !== 'production') {
 }
 
 const renderEpiComponent = (component, props, componentIndex) => {
-  const {nsAnswers, nsConsiderationHeader, nsConsiderationList, nsTitle} = component.epiComponent;
   if (props.state.epiComponent === 'yes' && typeof component.namespaces !== 'undefined' && component.namespaces !== null) {
+    const {nsConsiderationHeader, nsConsiderationList, nsTitle, nsAnswers} = component.epiComponent;
     return (
       <div key={'container' + componentIndex + 'epi'} id={'container' + componentIndex + 'epi'} className='form__group'>
         <div className='per_form_ns'>{nsTitle}</div>


### PR DESCRIPTION
#946
I left a variable definition outside of the conditional that checked for existence of the `epiComponent`
Switching these lines fixes the bug:
![image](https://user-images.githubusercontent.com/20410256/73294359-af1c6500-41d3-11ea-8590-4d8f2f961988.png)
![image](https://user-images.githubusercontent.com/20410256/73294388-bcd1ea80-41d3-11ea-9cf4-af01aef14a9c.png)
