### PR TITLE
hotfix for #954 - preparedness tab does not render in production

### DIFF
--- a/app/assets/scripts/components/preparedness/national-societies-engaged-per.js
+++ b/app/assets/scripts/components/preparedness/national-societies-engaged-per.js
@@ -48,8 +48,8 @@ export default class NationalSocietiesEngagedPer extends PureComponent {
     const charts = [];
 
     // Filters out data where 'region' is undefined.
-    this.preparedData = this.preparedData.filter(d => d.region)
-    
+    this.preparedData = this.preparedData.filter(d => d.region);
+
     this.preparedData.forEach((region) => {
       charts.push(
         <div key={'regionChart' + region.region.id} style={{float: 'left', width: '20%'}}>

--- a/app/assets/scripts/components/preparedness/national-societies-engaged-per.js
+++ b/app/assets/scripts/components/preparedness/national-societies-engaged-per.js
@@ -46,6 +46,10 @@ export default class NationalSocietiesEngagedPer extends PureComponent {
       return null;
     }
     const charts = [];
+
+    // Filters out data where 'region' is undefined.
+    this.preparedData = this.preparedData.filter(d => d.region)
+    
     this.preparedData.forEach((region) => {
       charts.push(
         <div key={'regionChart' + region.region.id} style={{float: 'left', width: '20%'}}>


### PR DESCRIPTION
This adds a hotfix to filter out data entries where `region` is undefined, that was causing the preparedness page not to render on production.

Would be great to be able to merge this soon as it's causing an error in production - #954 .

@szabozoltan69 @GregoryHorvath do you mind giving this a quick look / test and let me know if this seems okay?

cc @nanometrenat - we'd like to merge just this change into the `master` branch and have it deployed on production, that fixes #954 . 