### PR TITLE
[minor] change PER map legend text

### DIFF
--- a/app/assets/scripts/components/map/per-map/explanation-bubble.js
+++ b/app/assets/scripts/components/map/per-map/explanation-bubble.js
@@ -9,7 +9,7 @@ class ExplanationBubble extends React.Component {
     return (
       <figcaption className='map-vis__legend map-vis__legend--bottom-right legend'>
         <div>
-          <label className='form__label'>Last submitted phase</label>
+          <label className='form__label'>Current PER phase</label>
           <dl className='legend__dl legend__dl--colors'>
             <dt className='color color--orientation'>Green</dt>
             <dd>Orientation</dd>


### PR DESCRIPTION
Change legend text on per map to "Current PER phase" as per https://github.com/IFRCGo/go-frontend/issues/844#issuecomment-581823196

@necoline am going ahead and merging this in as it's a minor change.