### PR TITLE
adds fallback to all 'getPerComponent' results

### DIFF
--- a/app/assets/scripts/components/country/preparedness-column-graph.js
+++ b/app/assets/scripts/components/country/preparedness-column-graph.js
@@ -23,7 +23,7 @@ class PreparednessColumnBar extends React.Component {
       return component.selected_option > 1;
     }).map((component) => {
       component.formCode = this.formIds[component.form].code;
-      const perComponent = getPerComponent(component.formCode, component.question_id).shift();
+      const perComponent = getPerComponent(component.formCode, component.question_id);
       component.name = perComponent ? perComponent.name : 'n/a';
       component.epi = 0;
       component.component = 0;

--- a/app/assets/scripts/components/country/preparedness-summary.js
+++ b/app/assets/scripts/components/country/preparedness-summary.js
@@ -39,7 +39,7 @@ class PreparednessSummary extends React.Component {
       return component.selected_option > 1;
     }).map((component) => {
       component.formCode = this.formIds[component.form].code;
-      const perComponent = getPerComponent(component.formCode, component.question_id).shift();
+      const perComponent = getPerComponent(component.formCode, component.question_id);
       component.name = perComponent ? perComponent.name : 'n/a';
       component.epi = 0;
       component.component = 0;

--- a/app/assets/scripts/components/preparedness/global-preparedness-highlights.js
+++ b/app/assets/scripts/components/preparedness/global-preparedness-highlights.js
@@ -22,7 +22,7 @@ export default class GlobalPreparednessHighlights extends React.Component {
       const highPerformingComponents = [];
 
       this.props.data.data.results.forEach(result => {
-        const correspondingComponent = getPerComponent(result.code, result.question_id)[0];
+        const correspondingComponent = getPerComponent(result.code, result.question_id);
         if (typeof components[correspondingComponent.cid] === 'undefined') {
           components[correspondingComponent.cid] = {name: correspondingComponent.name, count: 1};
         } else {

--- a/app/assets/scripts/utils/get-per-components.js
+++ b/app/assets/scripts/utils/get-per-components.js
@@ -5,7 +5,7 @@ import { englishForm as a32Form } from './../components/per-forms/form-data/a3-2
 import { englishForm as a4Form } from './../components/per-forms/form-data/a4/english-data';
 import { englishForm as a5Form } from './../components/per-forms/form-data/a5/english-data';
 
-const defaultComponent = [{id: '', name: '', cid: 0}];
+const defaultComponent = {id: '', name: '', cid: 0};
 
 const components = {
   a1: [
@@ -150,7 +150,12 @@ const shortComponents = {
 export function getPerComponent (code, questionId) {
   code = code.replace(/-/g, '_');
   if (questionId.includes('epi')) {
-    return components[code].filter(question => question.id === questionId);
+    let selectedComponent = components[code].filter(question => question.id === questionId).shift() || null;
+    if (!selectedComponent) {
+      console.error(`Missing PER details for component ${code}, question ${questionId}`);
+      selectedComponent = defaultComponent;
+    }
+    return selectedComponent;
   } else {
     return getShortComponent(code, questionId);
   }
@@ -159,8 +164,8 @@ export function getPerComponent (code, questionId) {
 export function getShortComponent (code, questionId) {
   code = code.replace(/-/g, '_');
   questionId = questionId.split('q')[0];
-  let selectedShortComponent = shortComponents[code].filter(question => question.id === questionId);
-  if (!selectedShortComponent.length) {
+  let selectedShortComponent = shortComponents[code].filter(question => question.id === questionId).shift() || null;
+  if (!selectedShortComponent) {
     console.error(`Missing PER details for component ${code}, question ${questionId}`);
     selectedShortComponent = defaultComponent;
   }


### PR DESCRIPTION
- updates fallback for `getShortComponent` to apply the `.shift()` to the parent function rather than the children
- applies the fallback to `defaultValue` to all outputs of `getPerComponent` rather than just the output of `getShortComponent`

This should take care of any faulty requests to `PerComponents`