### PR TITLE
Add FACT and Rapid Response values together

### DIFF
--- a/app/assets/scripts/components/connected/personnel-table.js
+++ b/app/assets/scripts/components/connected/personnel-table.js
@@ -149,13 +149,18 @@ class PersonnelTable extends SFPComponent {
         label: <SortHeader id='emer' title='Emergency' sort={this.state.table.sort} onClick={''} /> // for filtering options check .../api/v2/personnel/?limit=2 - the Filters button, Ordering
       }];
 
+      // Should add the other types if needed
+      const typeLongNames = {
+        'rr': 'Rapid Response'
+      };
+
       const rows = data.results.map(o => ({
         id: o.id,
         startDateInterval: DateTime.fromISO(o.start_date).toISODate(),
         endDate: DateTime.fromISO(o.end_date).toISODate(),
         name: o.name,
         role: get(o, 'role', nope),
-        type: o.type.toUpperCase(),
+        type: o.type === 'rr' ? typeLongNames[o.type] : o.type.toUpperCase(),
         country: o.country_from ? <Link to={`/countries/${o.country_from.id}`} className='link--primary' title='View Country'>{o.country_from.society_name || o.country_from.name}</Link> : nope,
         deployed: o.deployment && o.deployment.country_deployed_to ? <Link to={`/countries/${o.deployment.country_deployed_to.id}`} className='link--primary' title='View Country'>{o.deployment.country_deployed_to.name}</Link> : nope,
         emer: o.deployment && o.deployment.event_deployed_to ? <Link to={`/emergencies/${o.deployment.event_deployed_to.id}`} className='link--primary' title='View Country'>{o.deployment.event_deployed_to.name}</Link> : nope

--- a/app/assets/scripts/components/connected/personnel-table.js
+++ b/app/assets/scripts/components/connected/personnel-table.js
@@ -27,6 +27,12 @@ const typeOptions = [
   { value: 'fact', label: 'FACT' }
 ];
 
+// Should add the other types if needed
+// These types reference types defined in the backend models here: https://github.com/IFRCGo/go-api/blob/e92b0ceadd70297a574fe4410d76eb7bf8614411/deployments/models.py#L98-L106
+const typeLongNames = {
+  'rr': 'Rapid Response'
+};
+
 class PersonnelTable extends SFPComponent {
   constructor (props) {
     super(props);
@@ -148,11 +154,6 @@ class PersonnelTable extends SFPComponent {
         id: 'emer',
         label: <SortHeader id='emer' title='Emergency' sort={this.state.table.sort} onClick={''} /> // for filtering options check .../api/v2/personnel/?limit=2 - the Filters button, Ordering
       }];
-
-      // Should add the other types if needed
-      const typeLongNames = {
-        'rr': 'Rapid Response'
-      };
 
       const rows = data.results.map(o => ({
         id: o.id,

--- a/app/assets/scripts/components/highlighted-operations/index.js
+++ b/app/assets/scripts/components/highlighted-operations/index.js
@@ -52,7 +52,7 @@ class HighlightedOperations extends React.Component {
       deployedPersonnel = 0;
       this.props.deployments.data.results
         .filter(deployment => {
-          return (deployment.type === 'heop' || deployment.type === 'rdrt' || deployment.type === 'fact') &&
+          return (deployment.type === 'heop' || deployment.type === 'rdrt' || deployment.type === 'fact' || deployment.type === 'rr') &&
             deployment.id === emergency.id;
         })
         .forEach(deployment => { deployedPersonnel += deployment.deployments; });

--- a/app/assets/scripts/views/deployments.js
+++ b/app/assets/scripts/views/deployments.js
@@ -135,7 +135,7 @@ class Deployments extends SFPComponent {
   renderHeaderStats () {
     const { data } = this.props.eruOwners;
     const { types } = this.props.activePersonnel;
-    const fact = types.fact || nope;
+    const fact = types.fact + types.rr || nope;
     const heop = types.heop || nope;
     const rdrt = types.rdrt || nope;
 
@@ -147,7 +147,7 @@ class Deployments extends SFPComponent {
               {n(data.deployed)}<small>Deployed ERUs</small>
             </li>
             <li className='stats-list__item stats-fact'>
-              {n(fact)}<small>Deployed FACTs</small>
+              {n(fact)}<small>Deployed Rapid Response</small>
             </li>
             <li className='stats-list__item stats-people'>
               {n(rdrt)}<small>Deployed RDRTs</small>


### PR DESCRIPTION
Issue: #965 

Changes:
- 'RR' to 'Rapid Response' in the Deployments table.
- Adds 'RR' and 'FACT' values together on the Deployments page and in the Highlighted Operations on the homepage.

Before merging:
- [ ] Check if I changed the right values for summing together 'FACT' and 'RR' numbers.
- [ ] Check if I missed any page where these values are used.