### PR TITLE
fixes #844 - black dot for phase 0 instead of grey

### DIFF
--- a/app/assets/scripts/components/map/per-map/factory/marker-layer-stylesheet-factory.js
+++ b/app/assets/scripts/components/map/per-map/factory/marker-layer-stylesheet-factory.js
@@ -13,6 +13,7 @@ class MarkerLayerStylesheetFactory {
       property: 'phaseCode',
       type: 'categorical',
       stops: [
+        ['0', '#CCCCCC'],
         ['1', '#00845F'],
         ['2', '#BD001C'],
         ['3', '#2D5086'],


### PR DESCRIPTION
Fixes bug where countries that had their phase as 0 showed up as black, when they should be incomplete / grey.