### PR TITLE
allow components to not have epiComponent defined, ref #994

### DIFF
--- a/app/assets/scripts/components/per-forms/per-form-component.js
+++ b/app/assets/scripts/components/per-forms/per-form-component.js
@@ -193,7 +193,7 @@ if (environment !== 'production') {
 }
 
 const renderEpiComponent = (component, props, componentIndex) => {
-  if (props.state.epiComponent === 'yes' && typeof component.namespaces !== 'undefined' && component.namespaces !== null) {
+  if (props.state.epiComponent === 'yes' && typeof component.namespaces !== 'undefined' && component.namespaces !== null && component.epiComponent) {
     const {nsConsiderationHeader, nsConsiderationList, nsTitle, nsAnswers} = component.epiComponent;
     return (
       <div key={'container' + componentIndex + 'epi'} id={'container' + componentIndex + 'epi'} className='form__group'>

--- a/app/assets/scripts/components/per-forms/per-form.js
+++ b/app/assets/scripts/components/per-forms/per-form.js
@@ -253,7 +253,7 @@ export default class PerForm extends React.Component {
         }
       }
 
-      if (this.state.epiComponent === 'yes' && typeof component.namespaces !== 'undefined' && component.namespaces !== null) {
+      if (this.state.epiComponent === 'yes' && typeof component.namespaces !== 'undefined' && component.namespaces !== null && component.epiComponent) {
         if (document.querySelectorAll('[name=\'c' + componentIndex + 'epi\']:checked').length < 1) {
           document.getElementById('container' + componentIndex + 'epi').style.backgroundColor = '#FEB8B8';
           if (formError.firstQuestionOffset === 0) {


### PR DESCRIPTION
Fixes bug where if a form component did not have an `epiComponent` defined and you selected `Yes` for Epidemics on a PER form, the page would crash.

Refs #994