### PR TITLE
Added RDRT into RR for Deployments stats

### DIFF
--- a/app/assets/scripts/views/deployments.js
+++ b/app/assets/scripts/views/deployments.js
@@ -136,22 +136,18 @@ class Deployments extends SFPComponent {
   renderHeaderStats () {
     const { data } = this.props.eruOwners;
     const { types } = this.props.activePersonnel;
-    const fact = types.fact + types.rr || nope;
+    const fact = types.fact + types.rr + types.rdrt || nope;
     const heop = types.heop || nope;
-    const rdrt = types.rdrt || nope;
 
     return (
       <div className='inpage__introduction'>
         <div className='header-stats'>
-          <ul className='stats-list'>
+          <ul className='stats-list-deployments'>
             <li className='stats-list__item stats-eru'>
               {n(data.deployed)}<small>Deployed ERUs</small>
             </li>
             <li className='stats-list__item stats-fact'>
               {n(fact)}<small>Deployed Rapid Response</small>
-            </li>
-            <li className='stats-list__item stats-people'>
-              {n(rdrt)}<small>Deployed RDRTs</small>
             </li>
             <li className='stats-list__item stats-heops'>
               {n(heop)}<small>Deployed Heops</small>

--- a/app/assets/styles/global/_inpages.scss
+++ b/app/assets/styles/global/_inpages.scss
@@ -222,6 +222,61 @@
   }
 }
 
+.stats-list-deployments {
+  list-style: none;
+  @include column(12/12);
+  @include media(large-up) {
+    display: flex;
+    flex-flow: row wrap;
+  }
+  li {
+    @include column(12/12);
+    font-size: 2.25rem;
+    line-height: 3rem;
+    padding-bottom: $global-spacing;
+    border-right: 0;
+    padding-left: $global-spacing * 3.5;
+    border-bottom: solid 1px rgba($base-color, 0.18);
+    margin-bottom: $global-spacing;
+    &:last-child {
+      border-right: none;
+      border-bottom: none;
+    }
+    @include media(large-up) {
+      @include column(4/12);
+      border-right: solid 1px rgba($base-color, 0.18);
+      border-bottom: 0;
+      padding-right: $global-spacing;
+      margin-bottom: 0;
+    }
+  }
+  .stat-double {
+    @include media(large-up) {
+      width: auto;
+      & + .stat-double {
+        padding-left: $global-spacing/2;
+      }
+    }
+  }
+  .stat-borderless {
+    border-right: none;
+    border-bottom: 0;
+    padding-bottom: 0;
+  }
+  small {
+    display: block;
+    font-size: 0.875rem;
+    color: $light-base-color;
+    text-transform: uppercase;
+    line-height: 1.25rem;
+    @include media(medium-up) {
+      font-size: 0.875rem;
+    }
+    @include media(large-up) {
+      font-size: 1rem;
+    }
+  }
+}
 
 .stats-emergencies {
   background-image: url('/assets/graphics/layout/emergency.svg');


### PR DESCRIPTION
@batpad There could be a more sophisticated way to do login in `.scss` files for these kind of stuff. I basically just copied the `.stats-list` section as a whole and changed `@include column(4/12);` to have only 3 columns (since `.stats-list` is used by the Emergencies page too).

**Feel free to change/fix or comment your thoughts please before merging this.**