### PR TITLE
Fix Disaster Type missing for ops. on Country page

### DIFF
--- a/app/assets/scripts/views/countries.js
+++ b/app/assets/scripts/views/countries.js
@@ -456,7 +456,7 @@ class AdminArea extends SFPComponent {
         ) : (
           nope
         ),
-        dtype: o.dtype,
+        dtype: o.dtype.name,
         requestAmount: n(o.amount_requested),
         fundedAmount: n(o.amount_funded),
         active: new Date(o.end_date).getTime() > now ? 'Active' : 'Inactive'


### PR DESCRIPTION
Disaster Types were missing from the Operations table on the Country-Edit page.