### PR TITLE
Last 3 months Emer. back to last month Emer.

### DIFF
--- a/app/assets/scripts/actions/index.js
+++ b/app/assets/scripts/actions/index.js
@@ -203,10 +203,10 @@ export function getEmergenciesList (page = 1, filters = {}) {
 }
 
 export const GET_LAST_MO_EMERGENCIES = 'GET_LAST_MO_EMERGENCIES';
-export function getLast3MonthsEmergencies () {
+export function getLastMonthsEmergencies () {
   const f = buildAPIQS({
-    disaster_start_date__gt: DateTime.utc().minus({days: 90}).startOf('day').toISO(),
-    limit: 600,
+    disaster_start_date__gt: DateTime.utc().minus({days: 30}).startOf('day').toISO(),
+    limit: 500,
     ordering: '-disaster_start_date'
   });
   return fetchJSON(`api/v2/event/?${f}`, GET_LAST_MO_EMERGENCIES, {});

--- a/app/assets/scripts/views/emergencies.js
+++ b/app/assets/scripts/views/emergencies.js
@@ -10,12 +10,12 @@ import FieldReportsTable from '../components/connected/field-reports-table';
 import EmergenciesDash from '../components/connected/emergencies-dash';
 import EmergenciesTable from '../components/connected/emergencies-table';
 
-import { getLast3MonthsEmergencies, getAggregateEmergencies } from '../actions';
+import { getLastMonthsEmergencies, getAggregateEmergencies } from '../actions';
 import { environment } from '../config';
 
 class Emergencies extends React.Component {
   componentDidMount () {
-    this.props._getLast3MonthsEmergencies();
+    this.props._getLastMonthsEmergencies();
     this.props._getAggregateEmergencies(DateTime.local().minus({months: 11}).startOf('day').toISODate(), 'month');
   }
 
@@ -52,7 +52,7 @@ class Emergencies extends React.Component {
 
 if (environment !== 'production') {
   Emergencies.propTypes = {
-    _getLast3MonthsEmergencies: T.func,
+    _getLastMonthsEmergencies: T.func,
     _getAggregateEmergencies: T.func,
     lastMonth: T.object,
     aggregate: T.object
@@ -69,7 +69,7 @@ const selector = (state) => ({
 
 const dispatcher = (dispatch) => ({
   _getAggregateEmergencies: (...args) => dispatch(getAggregateEmergencies(...args)),
-  _getLast3MonthsEmergencies: () => dispatch(getLast3MonthsEmergencies())
+  _getLastMonthsEmergencies: () => dispatch(getLastMonthsEmergencies())
 });
 
 export default connect(selector, dispatcher)(Emergencies);


### PR DESCRIPTION
Changed back the values on top of Emergencies page to show the correct values of 'last 30 days' instead of 'last 90 days'.