### PR TITLE
Release/v4.1.2

### DIFF
--- a/app/assets/scripts/actions/index.js
+++ b/app/assets/scripts/actions/index.js
@@ -203,10 +203,10 @@ export function getEmergenciesList (page = 1, filters = {}) {
 }
 
 export const GET_LAST_MO_EMERGENCIES = 'GET_LAST_MO_EMERGENCIES';
-export function getLast3MonthsEmergencies () {
+export function getLastMonthsEmergencies () {
   const f = buildAPIQS({
-    disaster_start_date__gt: DateTime.utc().minus({days: 90}).startOf('day').toISO(),
-    limit: 600,
+    disaster_start_date__gt: DateTime.utc().minus({days: 30}).startOf('day').toISO(),
+    limit: 500,
     ordering: '-disaster_start_date'
   });
   return fetchJSON(`api/v2/event/?${f}`, GET_LAST_MO_EMERGENCIES, {});

--- a/app/assets/scripts/views/countries.js
+++ b/app/assets/scripts/views/countries.js
@@ -456,7 +456,7 @@ class AdminArea extends SFPComponent {
         ) : (
           nope
         ),
-        dtype: o.dtype,
+        dtype: o.dtype.name,
         requestAmount: n(o.amount_requested),
         fundedAmount: n(o.amount_funded),
         active: new Date(o.end_date).getTime() > now ? 'Active' : 'Inactive'

--- a/app/assets/scripts/views/deployments.js
+++ b/app/assets/scripts/views/deployments.js
@@ -136,7 +136,10 @@ class Deployments extends SFPComponent {
   renderHeaderStats () {
     const { data } = this.props.eruOwners;
     const { types } = this.props.activePersonnel;
-    const fact = types.fact + types.rr + types.rdrt || nope;
+    let fact = nope;
+    if (types.fact || types.rr || types.rdrt) {
+      fact = (types.fact || 0) + (types.rr || 0) + (types.rdrt || 0);
+    }
     const heop = types.heop || nope;
 
     return (

--- a/app/assets/scripts/views/emergencies.js
+++ b/app/assets/scripts/views/emergencies.js
@@ -10,12 +10,12 @@ import FieldReportsTable from '../components/connected/field-reports-table';
 import EmergenciesDash from '../components/connected/emergencies-dash';
 import EmergenciesTable from '../components/connected/emergencies-table';
 
-import { getLast3MonthsEmergencies, getAggregateEmergencies } from '../actions';
+import { getLastMonthsEmergencies, getAggregateEmergencies } from '../actions';
 import { environment } from '../config';
 
 class Emergencies extends React.Component {
   componentDidMount () {
-    this.props._getLast3MonthsEmergencies();
+    this.props._getLastMonthsEmergencies();
     this.props._getAggregateEmergencies(DateTime.local().minus({months: 11}).startOf('day').toISODate(), 'month');
   }
 
@@ -52,7 +52,7 @@ class Emergencies extends React.Component {
 
 if (environment !== 'production') {
   Emergencies.propTypes = {
-    _getLast3MonthsEmergencies: T.func,
+    _getLastMonthsEmergencies: T.func,
     _getAggregateEmergencies: T.func,
     lastMonth: T.object,
     aggregate: T.object
@@ -69,7 +69,7 @@ const selector = (state) => ({
 
 const dispatcher = (dispatch) => ({
   _getAggregateEmergencies: (...args) => dispatch(getAggregateEmergencies(...args)),
-  _getLast3MonthsEmergencies: () => dispatch(getLast3MonthsEmergencies())
+  _getLastMonthsEmergencies: () => dispatch(getLastMonthsEmergencies())
 });
 
 export default connect(selector, dispatcher)(Emergencies);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "go-frontend",
-  "version": "4.1.0",
+  "version": "4.1.2",
   "description": "",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Minor Bugfix Release: v4.1.2

This is a minor bugfix release.

### Changelog

It fixes:

 - A bug with that Rapid Response calculation (would error if one of the types was missing): https://github.com/IFRCGo/go-frontend/pull/1029
 - Showing Disaster Type correctly on Country page: #920 
 - Show data for last 30 days on Emergency page to fix discrepancy in numbers: https://github.com/IFRCGo/go-frontend/pull/1032

Thank you @GregoryHorvath for these quick bug fixes. Please add any notes / links to existing tickets I may have missed.

@teklal the Rapid Response bug may not require testing - it was just a bug when one of the types was missing and may not require testing (just testing that the Rapid Response values look correct is probably fine).

@teklal if you're able to confirm these things work fine, these are all pretty minor bug-fixes and I can do another quick deploy to production. Please reach out to me or @GregoryHorvath if anything needs clarification.

cc @LukeCaley