### PR TITLE
Response docs ordering

### DIFF
--- a/app/assets/scripts/utils/utils.js
+++ b/app/assets/scripts/utils/utils.js
@@ -228,7 +228,11 @@ export function getRecordsByType (types, records) {
   recordsSorted.forEach(record => {
     if (record.type) {
       const recordTypeId = record.type.id;
-      recordsByType[recordTypeId].items.push(record);
+      if (record.is_pinned) {
+        recordsByType[recordTypeId].items.splice(0, 0, record);
+      } else {
+        recordsByType[recordTypeId].items.push(record);
+      }
     }
   });
 

--- a/app/assets/scripts/utils/utils.js
+++ b/app/assets/scripts/utils/utils.js
@@ -3,6 +3,7 @@ import _get from 'lodash.get';
 import _groupBy from 'lodash.groupby';
 import _toNumber from 'lodash.tonumber';
 import _find from 'lodash.find';
+import _filter from 'lodash.filter';
 import { DateTime } from 'luxon';
 
 import { getCentroid } from './country-centroids';
@@ -253,11 +254,27 @@ export function getRecordsByType (types, records) {
 
   // sort the primary records based on the order defined above.
   recordsByPriority['true'].sort((a, b) => {
-    return orderedIds.indexOf(a.typeId) - orderedIds.indexOf(b.typeId);
+    const aIndex = orderedIds.indexOf(a.typeId);
+    const bIndex = orderedIds.indexOf(b.typeId);
+    if (aIndex >= 0 && bIndex >= 0) {
+      return orderedIds.indexOf(a.typeId) - orderedIds.indexOf(b.typeId);
+    }
+  });
+
+  // // Filter out non-primary types that doesn't have any records
+  recordsByPriority['false'] = _filter(recordsByPriority['false'], (records) => {
+    if (records.items.length) {
+      return records;
+    }
   });
 
   // append the non primary records
-  const sortedRecordsByType = recordsByPriority['true'].concat(recordsByPriority['false']);
+  let sortedRecordsByType;
+  if (recordsByPriority['false']) {
+    sortedRecordsByType = recordsByPriority['true'].concat(recordsByPriority['false']);
+  } else {
+    sortedRecordsByType = recordsByPriority['true'];
+  }
 
   return sortedRecordsByType;
 }

--- a/app/assets/scripts/utils/utils.js
+++ b/app/assets/scripts/utils/utils.js
@@ -215,6 +215,7 @@ export function getRecordsByType (types, records) {
     memo[typeId] = {
       'title': _find(types.data.results, result => result.id === Number(typeId)).type,
       'typeId': typeId,
+      'is_primary': _find(types.data.results, result => result.id === Number(typeId)).is_primary,
       'items': []
     };
     return memo;
@@ -242,9 +243,17 @@ export function getRecordsByType (types, records) {
     '1', // ERU Reports
     '3' // Information Products
   ];
-  const sortedRecordsByType = Object.values(recordsByType);
-  sortedRecordsByType.sort((a, b) => {
+
+  // group records based on primary and others.
+  const recordsByPriority = _groupBy(Object.values(recordsByType), 'is_primary');
+
+  // sort the primary records based on the order defined above.
+  recordsByPriority['true'].sort((a, b) => {
     return orderedIds.indexOf(a.typeId) - orderedIds.indexOf(b.typeId);
   });
+
+  // append the non primary records
+  const sortedRecordsByType = recordsByPriority['true'].concat(recordsByPriority['false']);
+
   return sortedRecordsByType;
 }

--- a/app/assets/scripts/views/emergency.js
+++ b/app/assets/scripts/views/emergency.js
@@ -110,6 +110,7 @@ class Emergency extends React.Component {
   getEvent (id) {
     showGlobalLoading();
     this.props._getEventById(id);
+    this.props._getSitrepsByEventId(id);
   }
 
   getAppealDocuments (event) {

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "lodash": "^4.17.12",
     "lodash.clonedeep": "^4.5.0",
     "lodash.defaultsdeep": "^4.6.1",
+    "lodash.filter": "^4.6.0",
     "lodash.find": "^4.6.0",
     "lodash.get": "^4.4.2",
     "lodash.groupby": "^4.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6880,6 +6880,11 @@ lodash.escape@~2.4.1:
     lodash._reunescapedhtml "~2.4.1"
     lodash.keys "~2.4.1"
 
+lodash.filter@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.filter/-/lodash.filter-4.6.0.tgz#668b1d4981603ae1cc5a6fa760143e480b4c4ace"
+  integrity sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4=
+
 lodash.find@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.find/-/lodash.find-4.6.0.tgz#cb0704d47ab71789ffa0de8b97dd926fb88b13b1"


### PR DESCRIPTION
This PR should go along with https://github.com/IFRCGo/go-api/pull/639
* [x] Sort primary response docs with the specified order
* [x] Add non-primary response docs sorted by timestamp docs
* [x] Pin documents to the top of the list if `is_pinned`

cc @batpad 
