### PR TITLE
decouples the budget calculations from Appeals

### DIFF
--- a/app/assets/scripts/reducers/overall-stats.js
+++ b/app/assets/scripts/reducers/overall-stats.js
@@ -54,17 +54,18 @@ function appealsList (state = appealsListInitialState, action) {
           if (endTime > now) {
             acc.activeDrefs++;
           }
+        }
 
         // Appeal.
-        } else if (object.atype === 1 || object.atype === 2) {
+        if (object.atype === 1 || object.atype === 2) {
           acc.totalAppeals++;
           if (endTime > now) {
             acc.activeAppeals++;
           }
-          const amountFunded = _toNumber(object.amount_funded);
-          acc.appealsBudget += amountRequested;
-          acc.appealsFunding += amountFunded;
         }
+        const amountFunded = _toNumber(object.amount_funded);
+        acc.appealsBudget += amountRequested;
+        acc.appealsFunding += amountFunded;
         return acc;
       }, struct);
 

--- a/app/assets/scripts/reducers/overall-stats.js
+++ b/app/assets/scripts/reducers/overall-stats.js
@@ -143,10 +143,10 @@ function appealsListStats (state = appealsListStatsInitialState, action) {
           if (endTime > now) {
             acc.activeAppeals++;
           }
-          const amountFunded = _toNumber(object.amount_funded);
-          acc.appealsBudget += amountRequested;
-          acc.appealsFunding += amountFunded;
         }
+        const amountFunded = _toNumber(object.amount_funded);
+        acc.appealsBudget += amountRequested;
+        acc.appealsFunding += amountFunded;
         return acc;
       }, struct);
 


### PR DESCRIPTION
#915 
The funding calculations were applied specifically to Appeals and not to DREFs. I am unclear as to whether this was due a miscommunication during ticketing phase [here](https://github.com/IFRCGo/go-frontend/issues/847) or simply a code error.

This change moves the funding calculation to be applied to each object in the reduce rather than just the appeals.

**Note:**  The original logic for this component was copied from the region key figures. This change is applied to countries only and does not adjust the way the DREF and Appeals funding is calculated on the region page.

![image](https://user-images.githubusercontent.com/20410256/77440100-465dfd00-6dbe-11ea-8dbb-0304accea908.png)
