### PR TITLE
removes 'save'

### DIFF
--- a/app/assets/scripts/views/field-report-form/index.js
+++ b/app/assets/scripts/views/field-report-form/index.js
@@ -728,7 +728,7 @@ class FieldReportForm extends React.Component {
   }
 
   render () {
-    const submitTitle = this.state.step === 4 ? 'Submit' : 'Save and Continue';
+    const submitTitle = this.state.step === 4 ? 'Submit' : 'Continue';
     return (
       <App className='page--frep-form'>
         <section className='inpage'>


### PR DESCRIPTION
#1056 
deployed: https://ifrc-go-fix-1056-field-report-continue.surge.sh/

Removes 'Save' from the 'Continue' button at the bottom of the report section

![image](https://user-images.githubusercontent.com/20410256/77703526-68f43f80-6f91-11ea-8e14-7a4a2e50be0e.png)
