### PR TITLE
Fix/1013 slug requests

### DIFF
--- a/app/assets/scripts/components/admin-area-elements.js
+++ b/app/assets/scripts/components/admin-area-elements.js
@@ -28,22 +28,6 @@ class _KeyFigures extends React.Component {
   }
 }
 
-class _Snippets extends React.Component {
-  render () {
-    const { fetching, fetched, error, data } = this.props.data;
-    if (fetching || error || (fetched && !data.results.length)) return null;
-    return (
-      <Fold id='graphics' title='Additional Graphics' wrapper_class='additional-graphics'>
-        <div className='iframe__container'>
-          {data.results.map(o => o.snippet ? <div className='snippet__item' key={o.id} dangerouslySetInnerHTML={{__html: o.snippet}} />
-            : o.image ? <div key={o.id} className='snippet__item snippet__image'><img src={o.image}/></div> : null
-          )}
-        </div>
-      </Fold>
-    );
-  }
-}
-
 class _Contacts extends React.Component {
   render () {
     const { data } = this.props;
@@ -94,12 +78,10 @@ class _Links extends React.Component {
 
 if (environment !== 'production') {
   _KeyFigures.propTypes = { data: T.object };
-  _Snippets.propTypes = { data: T.object };
   _Contacts.propTypes = { data: T.object };
   _Links.propTypes = { data: T.object };
 }
 
 export const KeyFigures = _KeyFigures;
-export const Snippets = _Snippets;
 export const Contacts = _Contacts;
 export const Links = _Links;

--- a/app/assets/scripts/components/emergencies/snippets.js
+++ b/app/assets/scripts/components/emergencies/snippets.js
@@ -1,0 +1,66 @@
+import React, { Component } from 'React';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import { get } from '../../utils/utils';
+import Fold from '../fold';
+import TabContent from '../tab-content';
+import { NO_DATA } from '../../utils/constants';
+
+import {
+  getEventSnippets,
+//   getSitrepsByEventId,
+} from '../../actions/';
+
+class Snippets extends Component {
+  componentDidMount () {
+    this.props._getEventSnippets(this.props.eventId);
+  }
+  render () {
+    const { fetching, fetched, error, data } = this.props.snippets;
+    if (fetching || error || (fetched && !data.results.length)) return null;
+    return (
+      <TabContent showError={true} isError={!get(data, 'results.length')} errorMessage={ NO_DATA } title="Additional Graphics">
+        <Fold id='graphics' title='Additional Graphics' wrapper_class='additional-graphics'>
+          <div className='iframe__container'>
+            {data.results.map(o => o.snippet ? <div className='snippet__item' key={o.id} dangerouslySetInnerHTML={{__html: o.snippet}} />
+              : o.image ? <div key={o.id} className='snippet__item snippet__image'><img src={o.image}/></div> : null
+            )}
+          </div>
+        </Fold>
+      </TabContent>
+    );
+  }
+}
+
+Snippets.propTypes = {
+  _getEventSnippets: PropTypes.func,
+  eventId: PropTypes.string,
+  snippets: PropTypes.object
+  // _getSitrepsByEventId: T.func,
+};
+
+// /////////////////////////////////////////////////////////////////// //
+// Connect functions
+
+const selector = (state, ownProps) => ({
+  snippets: get(state.event.snippets, ownProps.eventId, {
+    data: {
+      results: []
+    },
+    fetching: false,
+    fetched: false
+  }),
+//   situationReports: get(state.situationReports, ['reports', ownProps.eventId], {
+//     data: {},
+//     fetching: false,
+//     fetched: false
+//   })
+});
+
+const dispatcher = (dispatch) => ({
+  _getEventSnippets: (...args) => dispatch(getEventSnippets(...args))
+//   _getSitrepsByEventId: (...args) => dispatch(getSitrepsByEventId(...args)),
+});
+
+export default withRouter(connect(selector, dispatcher)(Snippets));

--- a/app/assets/scripts/components/emergencies/snippets.js
+++ b/app/assets/scripts/components/emergencies/snippets.js
@@ -7,10 +7,7 @@ import Fold from '../fold';
 import TabContent from '../tab-content';
 import { NO_DATA } from '../../utils/constants';
 
-import {
-  getEventSnippets,
-//   getSitrepsByEventId,
-} from '../../actions/';
+import { getEventSnippets } from '../../actions/';
 
 class Snippets extends Component {
   componentDidMount () {
@@ -37,7 +34,6 @@ Snippets.propTypes = {
   _getEventSnippets: PropTypes.func,
   eventId: PropTypes.string,
   snippets: PropTypes.object
-  // _getSitrepsByEventId: T.func,
 };
 
 // /////////////////////////////////////////////////////////////////// //
@@ -50,17 +46,11 @@ const selector = (state, ownProps) => ({
     },
     fetching: false,
     fetched: false
-  }),
-//   situationReports: get(state.situationReports, ['reports', ownProps.eventId], {
-//     data: {},
-//     fetching: false,
-//     fetched: false
-//   })
+  })
 });
 
 const dispatcher = (dispatch) => ({
   _getEventSnippets: (...args) => dispatch(getEventSnippets(...args))
-//   _getSitrepsByEventId: (...args) => dispatch(getSitrepsByEventId(...args)),
 });
 
 export default withRouter(connect(selector, dispatcher)(Snippets));

--- a/app/assets/scripts/views/emergency.js
+++ b/app/assets/scripts/views/emergency.js
@@ -41,7 +41,7 @@ import Fold from '../components/fold';
 import TabContent from '../components/tab-content';
 import ErrorPanel from '../components/error-panel';
 import Expandable from '../components/expandable';
-import { Snippets } from '../components/admin-area-elements';
+import Snippets from '../components/emergencies/snippets';
 import SurgeAlertsTable from '../components/connected/alerts-table';
 import PersonnelTable from '../components/connected/personnel-table';
 import EruTable from '../components/connected/eru-table';
@@ -112,8 +112,6 @@ class Emergency extends React.Component {
   getEvent (id) {
     showGlobalLoading();
     this.props._getEventById(id);
-    this.props._getEventSnippets(id);
-    this.props._getSitrepsByEventId(id);
   }
 
   getAppealDocuments (event) {
@@ -593,9 +591,7 @@ class Emergency extends React.Component {
               </TabPanel>
 
               <TabPanel>
-                <TabContent showError={true} isError={!get(this.props.snippets, 'data.results.length')} errorMessage={ NO_DATA } title="Additional Graphics">
-                  <Snippets data={this.props.snippets} />
-                </TabContent>
+                <Snippets eventId={get(this.props.event, 'data.id')} />
               </TabPanel>
             </div>
           </div>

--- a/app/assets/scripts/views/emergency.js
+++ b/app/assets/scripts/views/emergency.js
@@ -65,7 +65,6 @@ class Emergency extends React.Component {
       },
       subscribed: false
     };
-    this.handleSitrepFilter = this.handleSitrepFilter.bind(this);
     this.addSubscription = this.addSubscription.bind(this);
     this.delSubscription = this.delSubscription.bind(this);
     this.isSubscribed = this.isSubscribed.bind(this);
@@ -124,23 +123,6 @@ class Emergency extends React.Component {
   onAppealClick (id, e) {
     e.preventDefault();
     this.setState({ selectedAppeal: id });
-  }
-
-  handleSitrepFilter (state, value) {
-    const next = Object.assign({}, this.state.sitrepFilters, {
-      [state]: value
-    });
-
-    const { date, type } = next;
-    let filters = {};
-    if (date !== 'all') {
-      filters.created_at__gte = datesAgo[date]();
-    }
-    if (type !== 'all') {
-      filters.type = type;
-    }
-    this.props._getSitrepsByEventId(this.props.match.params.id, filters);
-    this.setState({ sitrepFilters: next });
   }
 
   isSubscribed (nextProps) {

--- a/app/assets/scripts/views/emergency.js
+++ b/app/assets/scripts/views/emergency.js
@@ -32,7 +32,6 @@ import {
 import {
   get,
   mostRecentReport,
-  datesAgo,
   getRecordsByType
 } from '../utils/utils/';
 


### PR DESCRIPTION
#1013 
- creates child component for snippets
- moves snippet content from `admin-area-elements` to snippet component
- removes unused 'sitRepFilter'

![image](https://user-images.githubusercontent.com/20410256/77852575-5bb39c80-71ad-11ea-91e3-6847a33db2d9.png)
