### PR TITLE
Duplicated FormCheckboxGroup for Actions

### DIFF
--- a/app/assets/scripts/components/form-elements/checkbox-group-actions.js
+++ b/app/assets/scripts/components/form-elements/checkbox-group-actions.js
@@ -1,0 +1,88 @@
+'use strict';
+import React from 'react';
+import { PropTypes as T } from 'prop-types';
+import c from 'classnames';
+import _cloneDeep from 'lodash.clonedeep';
+import _get from 'lodash.get';
+
+import { FormDescription } from './misc';
+import FormCheckbox from './checkbox';
+
+export default class FormCheckboxGroupActions extends React.Component {
+  onCheckChange (opValue) {
+    const { values, onChange } = this.props;
+    const valueObject = values.find(obj => obj.value === opValue);
+    const prevState = _get(values, [values.indexOf(valueObject), 'checked'], false);
+    let newVals = _cloneDeep(values);
+
+    newVals.map(val => ((val.value === opValue) ? (val.checked = !prevState) : null));
+    onChange(newVals);
+  }
+
+  render () {
+    const {
+      label,
+      name,
+      description,
+      options,
+      values,
+      classWrapper,
+      classLabel,
+      children
+    } = this.props;
+
+    return (
+      <div className={c('form__group', classWrapper)}>
+        <div className='form__inner-header'>
+          <div className='form__inner-headline'>
+            <label className={c('form__label', classLabel)}>{label}</label>
+            <FormDescription value={description} />
+          </div>
+        </div>
+        <div className='form__inner-body'>
+          {options.map(optionGroup => (
+            <React.Fragment>
+              {options.length > 1 ? (
+                <label key={optionGroup.label} className={c('form__label', classLabel)}>{optionGroup.label}</label>
+              ) : null}
+              <div className='form__options-group'>
+                {(optionGroup.options || options).map(option => {
+                  return (
+                    <FormCheckbox
+                      key={option.value}
+                      label={option.label}
+                      name={`${name}[]`}
+                      id={`${name.replace(/(\[|\])/g, '-')}-${option.value}`}
+                      value={option.value}
+                      checked={(values.find(({value}) => value === option.value) || {}).checked}
+                      onChange={this.onCheckChange.bind(this, option.value)}
+                      description={option.description} />
+                  );
+                })}
+              </div>
+            </React.Fragment>
+          ))}
+          {children || null}
+        </div>
+      </div>
+    );
+  }
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  FormCheckboxGroupActions.propTypes = {
+    label: T.string,
+    name: T.string,
+    description: T.oneOfType([
+      T.node,
+      T.object
+    ]),
+    options: T.array,
+    values: T.array,
+    classWrapper: T.string,
+    classLabel: T.string,
+    checked: T.bool,
+    children: T.node,
+    onChange: T.func
+  };
+}

--- a/app/assets/scripts/components/form-elements/checkbox-group.js
+++ b/app/assets/scripts/components/form-elements/checkbox-group.js
@@ -11,11 +11,10 @@ import FormCheckbox from './checkbox';
 export default class FormCheckboxGroup extends React.Component {
   onCheckChange (opValue) {
     const { values, onChange } = this.props;
-    const valueObject = values.find(obj => obj.value === opValue);
-    const prevState = _get(values, [values.indexOf(valueObject), 'checked'], false);
+    const prevState = _get(values, [opValue, 'checked'], false);
     let newVals = _cloneDeep(values);
 
-    newVals.map(val => ((val.value === opValue) ? (val.checked = !prevState) : null));
+    newVals[opValue].checked = !prevState;
     onChange(newVals);
   }
 
@@ -40,28 +39,19 @@ export default class FormCheckboxGroup extends React.Component {
           </div>
         </div>
         <div className='form__inner-body'>
-          {options.map(optionGroup => (
-            <React.Fragment>
-              {options.length > 1 ? (
-                <label key={optionGroup.label} className={c('form__label', classLabel)}>{optionGroup.label}</label>
-              ) : null}
-              <div className='form__options-group'>
-                {(optionGroup.options || options).map(option => {
-                  return (
-                    <FormCheckbox
-                      key={option.value}
-                      label={option.label}
-                      name={`${name}[]`}
-                      id={`${name.replace(/(\[|\])/g, '-')}-${option.value}`}
-                      value={option.value}
-                      checked={(values.find(({value}) => value === option.value) || {}).checked}
-                      onChange={this.onCheckChange.bind(this, option.value)}
-                      description={option.description} />
-                  );
-                })}
-              </div>
-            </React.Fragment>
-          ))}
+          <div className='form__options-group'>
+            {options.map((o, opValue) => (
+              <FormCheckbox
+                key={o.value}
+                label={o.label}
+                name={`${name}[]`}
+                id={`${name.replace(/(\[|\])/g, '-')}-${o.value}`}
+                value={o.value}
+                checked={_get(values, [opValue, 'checked'], false)}
+                onChange={this.onCheckChange.bind(this, opValue)}
+                description={o.description} />
+            ))}
+          </div>
           {children || null}
         </div>
       </div>

--- a/app/assets/scripts/views/field-report-form/cmp-action-checkboxes.js
+++ b/app/assets/scripts/views/field-report-form/cmp-action-checkboxes.js
@@ -5,9 +5,9 @@ import { PropTypes as T } from 'prop-types';
 import { environment } from '../../config';
 
 import {
-  FormTextarea,
-  FormCheckboxGroupActions
+  FormTextarea
 } from '../../components/form-elements/';
+import FormCheckboxGroupActions from '../../components/form-elements/checkbox-group-actions';
 
 export default class ActionsCheckboxes extends React.Component {
   constructor (props) {

--- a/app/assets/scripts/views/field-report-form/cmp-action-checkboxes.js
+++ b/app/assets/scripts/views/field-report-form/cmp-action-checkboxes.js
@@ -6,7 +6,7 @@ import { environment } from '../../config';
 
 import {
   FormTextarea,
-  FormCheckboxGroup
+  FormCheckboxGroupActions
 } from '../../components/form-elements/';
 
 export default class ActionsCheckboxes extends React.Component {
@@ -50,7 +50,7 @@ export default class ActionsCheckboxes extends React.Component {
       }));
 
     return (
-      <FormCheckboxGroup
+      <FormCheckboxGroupActions
         label={label}
         key={label}
         description={description}
@@ -68,7 +68,7 @@ export default class ActionsCheckboxes extends React.Component {
           classLabel='label-secondary'
           value={values.description}
           onChange={this.onDescriptionChange} />
-      </FormCheckboxGroup>
+      </FormCheckboxGroupActions>
     );
   }
 }


### PR DESCRIPTION
@necoline Could you look into this please if there is any other better way to handle this issue? This PR is just the ugly/fast version of fixing the problem by me rolling the changes back of https://github.com/IFRCGo/go-frontend/commit/1ab561ad4de7f5d8200c027f8f911d198b04127c and duplicating the new version of `FormCheckboxGroup` -> `FormCheckboxGroupActions` to use for Field Reports.

Ticket: https://github.com/IFRCGo/go-frontend/issues/1130

cc @batpad Just in case if Neco was not available this week.