### PR TITLE
#1007 - add global header banner with link to covid emergency

### DIFF
--- a/app/assets/scripts/components/global-header-banner.js
+++ b/app/assets/scripts/components/global-header-banner.js
@@ -1,0 +1,15 @@
+'use strict';
+import React from 'react';
+
+class GlobalHeaderBanner extends React.PureComponent {
+  render () {
+    return (
+      <div className='global__banner global__banner--danger text-center'>
+        <span>You may find more information related to the ongoing COVID-19 Global Operation by clicking </span>
+        <a href='https://go.ifrc.org/emergencies/3972'>here.</a>
+      </div>
+    );
+  }
+}
+
+export default GlobalHeaderBanner;

--- a/app/assets/scripts/views/app.js
+++ b/app/assets/scripts/views/app.js
@@ -9,12 +9,14 @@ import Header from '../components/header';
 import MobileHeader from '../components/mobile-header';
 import Footer from '../components/footer';
 import GlobalLoading from '../components/global-loading';
+import GlobalHeaderBanner from '../components/global-header-banner';
 import SysAlerts from '../components/system-alerts';
 
 class App extends React.Component {
   render () {
     return (
       <div className={c('page', this.props.className)}>
+        <GlobalHeaderBanner />
         <GlobalLoading />
         <Header />
         <MobileHeader />

--- a/app/assets/styles/global/_global-banner.scss
+++ b/app/assets/styles/global/_global-banner.scss
@@ -1,0 +1,19 @@
+/* ==========================================================================
+   Global: Banners
+   ========================================================================== */
+
+.global__banner {
+  color: #fff;
+  font-size: $font-size-sm;
+  font-weight: $base-font-medium;
+  padding: ($global-spacing / 1.5);
+
+  a {
+    color: currentColor;
+    border-bottom: 1px solid #fff;
+  }
+}
+
+.global__banner--danger {
+  background-color: $primary-color;
+}

--- a/app/assets/styles/main.scss
+++ b/app/assets/styles/main.scss
@@ -74,6 +74,7 @@
 @import "global/pages";
 @import "global/inpages";
 @import "global/folds";
+@import "global/global-banner";
 @import "global/scrollbar-custom";
 @import "global/page-prime-nav";
 @import "global/popovers";


### PR DESCRIPTION
Addresses #1007 , adding a site-wide banner with, currently, a hard-coded link to the COVID-19 emergency.

Testing URL: https://ifrc-go-feature-1007-covid-banner.surge.sh/

cc @GregoryHorvath @teklal @LukeCaley 