### PR TITLE
updates step 1 descriptions for covid

### DIFF
--- a/app/assets/scripts/utils/field-report-constants.js
+++ b/app/assets/scripts/utils/field-report-constants.js
@@ -533,29 +533,29 @@ export const fieldsStep1 = {
   'summary': {
     'EVT': {
       label: 'Title *',
-      desc: 'Add a new title (Country - Region: Hazard mm/yy) or link to an existing emergency'
+      desc: 'For Covid-19 Field Reports, please link to the country specific emergency page if one already exists. Please do not link to the Global emergency page.'
     },
     'EPI': {
       label: 'Title *',
-      desc: 'Add a new title (Country - Region: Hazard mm/yy) or link to an existing emergency'
+      desc: 'For Covid-19 Field Reports, please link to the country specific emergency page if one already exists. Please do not link to the Global emergency page.'
     },
     'EW': {
       label: 'Title *',
-      desc: 'Add a new title (Country - Region: Hazard mm/yy) or link to an existing emergency'
+      desc: 'For Covid-19 Field Reports, please link to the country specific emergency page if one already exists. Please do not link to the Global emergency page.'
     }
   },
   'disaster-type': {
     'EVT': {
       label: 'Disaster Type *',
-      desc: ''
+      desc: 'If Covid-19 select “Epidemic” as the disaster type'
     },
     'EPI': {
       label: 'Disaster Type *',
-      desc: ''
+      desc: 'If Covid-19 select “Epidemic” as the disaster type'
     },
     'EW': {
       label: 'Hazard Type *',
-      desc: ''
+      desc: 'If Covid-19 select “Epidemic” as the disaster type'
     }
   },
   'startDate': {

--- a/app/assets/scripts/views/field-report-form/index.js
+++ b/app/assets/scripts/views/field-report-form/index.js
@@ -357,7 +357,12 @@ class FieldReportForm extends React.Component {
           name='summary'
           id='summary'
           maxLength={100}
-          description={<div className='form__description'><p>{fields.summary[status].desc}</p><em>Example: GDACS Orange: Albania EQ Magnitude 5.4, Depth:10km(2019-11-30)</em></div>}
+          description={
+            <div className='form__description'>
+              <p>{fields.summary[status].desc}</p>
+              {/* <em>Example: GDACS Orange: Albania EQ Magnitude 5.4, Depth:10km(2019-11-30)</em> */}
+            </div>
+          }
           inputValue={this.state.data.summary}
           inputOnChange={this.onFieldChange.bind(this, 'summary')}
           selectOnChange={this.onFieldChange.bind(this, 'event')}
@@ -411,6 +416,7 @@ class FieldReportForm extends React.Component {
         <div className='form__group'>
           <div className='form__inner-header'>
             <label className='form__label'>{fields['disaster-type'][status].label}</label>
+            <p className='form__description'>{fields['disaster-type'][status].desc}</p>
           </div>
           <div className='form__inner-body'>
             <Select


### PR DESCRIPTION
- adds helper text for title and disaster type

![image](https://user-images.githubusercontent.com/20410256/80108000-cf955a80-8549-11ea-9324-50989a96aadf.png)

#1135 

test url https://ifrc-go-fix-1135-epi-guidance-text.surge.sh/reports/new
