### PR TITLE
allow actions to be saved with summary even no action checkboxes selected

### DIFF
--- a/app/assets/scripts/views/field-report-form/data-utils.js
+++ b/app/assets/scripts/views/field-report-form/data-utils.js
@@ -273,7 +273,7 @@ export function convertStateToPayload (originalState) {
       summary: originalState[src].description || '',
       actions: originalState[src].options.filter(o => o.checked).map(o => o.value)
     };
-  }).filter(o => o.actions.length);
+  }).filter(o => o.actions.length || o.summary !== '');
 
   // Planned Response Mapping
   // In the payload the status and value may mean different things.

--- a/app/assets/scripts/views/field-report.js
+++ b/app/assets/scripts/views/field-report.js
@@ -84,8 +84,13 @@ class FieldReport extends React.Component {
   renderActionsTaken (data, key, orgDisplayName) {
     const actions = get(data, 'actions_taken', []).find(d => d.organization === key);
 
-    // No actions have been taken
-    if (!actions || !Array.isArray(actions.actions) || !actions.actions.length) {
+    // If actions is undefined or not an array, return null
+    // FIXME: Not entirely sure why this is needed
+    if (!actions || !Array.isArray(actions.actions)) { return null; }
+
+    // if there are neither actions nor a summary, return null.
+    // FIXME: Ideally, this would never occur
+    if (actions.actions.length === 0 && actions.summary === '') {
       return null;
     }
 
@@ -360,7 +365,6 @@ class FieldReport extends React.Component {
             <div className='prose fold prose--responsive'>
               <div className='inner'>
                 <p className='inpage__note'>Last updated{data.user ? ` by ${data.user.username}` : null} on {lastTouchedAt}</p>
-                { data.is_covid_report ? (<h2>This is a COVID-19 Related Report.</h2>) : null }
                 {this.renderNumericDetails(data)}
                 { epiStatus === 'EPI' ? <DisplaySection title='Date of Data' inner={sitFieldsDate} /> : null }
                 <DisplaySection sectionClass='rich-text-section' title={ status === 'EW' ? 'Risk Analysis' : 'Description' } inner={get(data, 'description', false)} />


### PR DESCRIPTION
Fixes issue where if you put in an Actions summary, but did not select any checkboxes (or if there were no checkboxes for that actions section), it would not save the summary.

Now, it still creates a new ActionsTaken entry in the database if there are no actions selected, but only if the summary field is not empty, and this will display on the field report page, appear in the API, etc.
