### PR TITLE
Change PrivateRoute to Route for /reports/all

### DIFF
--- a/app/assets/scripts/main.js
+++ b/app/assets/scripts/main.js
@@ -101,7 +101,7 @@ const Root = () => (
         <AnonymousRoute exact path='/recover-account/:username/:token' component={RecoverAccount}/>
         <AnonymousRoute exact path='/recover-username' component={RecoverUsername}/>
         <PrivateRoute exact path='/reports/new' component={FieldReportForm}/>
-        <PrivateRoute exact path='/reports/all' render={props => <Table {...props} type='report' />} />
+        <Route exact path='/reports/all' render={props => <Table {...props} type='report' />} />
         <PrivateRoute exact path='/reports/:id/edit' component={FieldReportForm}/>
         <PrivateRoute exact path='/reports/:id' component={FieldReport}/>
         <Route exact path='/emergencies' component={Emergencies}/>


### PR DESCRIPTION
Closes #1118

URL to test is here: https://ifrc-go-fix-1118-public-frs.surge.sh/reports/all

You can see that the response called returns objects with `visiblity` equal to 3, which means they are public reports.