### PR TITLE
Fix permissions for public FRs

### DIFF
--- a/src/root/index.js
+++ b/src/root/index.js
@@ -101,7 +101,7 @@ const Root = () => (
         <PrivateRoute exact path='/reports/new' component={FieldReportForm}/>
         <Route exact path='/reports/all' render={props => <Table {...props} type='report' />} />
         <PrivateRoute exact path='/reports/:id/edit' component={FieldReportForm}/>
-        <PrivateRoute exact path='/reports/:id' component={FieldReport}/>
+        <Route exact path='/reports/:id' component={FieldReport}/>
         <Route exact path='/emergencies' component={Emergencies}/>
         <Route exact path='/emergencies/all' render={props => <Table {...props} type='emergency' />} />
         <Route exact path='/emergencies/:id' component={Emergency}/>

--- a/src/root/index.js
+++ b/src/root/index.js
@@ -99,7 +99,7 @@ const Root = () => (
         <AnonymousRoute exact path='/recover-account/:username/:token' component={RecoverAccount}/>
         <AnonymousRoute exact path='/recover-username' component={RecoverUsername}/>
         <PrivateRoute exact path='/reports/new' component={FieldReportForm}/>
-        <PrivateRoute exact path='/reports/all' render={props => <Table {...props} type='report' />} />
+        <Route exact path='/reports/all' render={props => <Table {...props} type='report' />} />
         <PrivateRoute exact path='/reports/:id/edit' component={FieldReportForm}/>
         <PrivateRoute exact path='/reports/:id' component={FieldReport}/>
         <Route exact path='/emergencies' component={Emergencies}/>

--- a/src/root/views/field-report.js
+++ b/src/root/views/field-report.js
@@ -326,7 +326,36 @@ class FieldReport extends React.Component {
   renderContent () {
     const { data } = this.props.report;
     if (!this.props.report.fetched || !data) {
-      return null;
+      // If the error is a 404, then either the report doesn't exist
+      // or the user is not authorized to see the resource
+      if (this.props.report.error && this.props.report.error.detail === "Not found.") {
+        return (
+          <section className='inpage'>
+            <header className='inpage__header'>
+              <div className='inner'>
+                <div className='inpage__headline-content'>
+                  <h1 className='inpage__title'>Resource Not Found!</h1>
+              </div>
+            </div>
+            </header>
+            <div className='inpage__body'>
+              <div className='inner'>
+                <div className='prose fold prose--responsive'>
+                  <div className='inner'>
+                    <p className='inpage_note'>The resource doesn't exist or you are not authorized to access this resource.</p>
+                    {
+                      (!this.props.user) ? <Link className='button button--medium button--primary-filled' to='/login' title='Go to login page'><span>Go to login</span></Link> 
+                        : <React.Fragment />
+                    }
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+        );
+      } else {
+        return null;
+      }
     }
     const infoBulletinOptions = {
       '0': 'No',
@@ -447,7 +476,8 @@ const selector = (state, ownProps) => ({
     data: {},
     fetching: false,
     fetched: false
-  })
+  }),
+  user: get(state.user)
 });
 
 const dispatcher = (dispatch) => ({


### PR DESCRIPTION
Closes #1118

- For `/reports/all` it will show all the public FRs when you're not logged in
- For `/reports/:id` it will
   - show the report if it's public and you're not logged in
   - show an error screen if you don't have the correct permissions

<img width="1402" alt="image" src="https://user-images.githubusercontent.com/719357/81997360-80f55080-961d-11ea-8ddf-dc8549d3c2df.png">

Let me know if the text copy should change. 

Surge: https://ifrc-go-fix-1118-public-private-frs.surge.sh