### PR TITLE
Change interval for country emergencies to a year

### DIFF
--- a/src/root/components/connected/emergencies-table.js
+++ b/src/root/components/connected/emergencies-table.js
@@ -83,7 +83,7 @@ class EmergenciesTable extends SFPComponent {
     if (state.filters.date !== 'all') {
       qs.disaster_start_date__gte = datesAgo[state.filters.date]();
     } else if (props.showRecent) {
-      qs.disaster_start_date__gte = recentInterval;
+      qs.disaster_start_date__gte = datesAgo['year']();
     }
 
     if (state.filters.dtype !== 'all') {


### PR DESCRIPTION
Previous default interval was set to `recentInterval` which is 30 days.

Surge: https://ifrc-go-feature-1132-recent-emergencies.surge.sh
Closes #1132 