### PR TITLE
add script to regenerate json of questions to use in backend, refs #1137

### DIFF
--- a/src/root/components/per-forms/form-data/README.md
+++ b/src/root/components/per-forms/form-data/README.md
@@ -1,0 +1,1 @@
+Run `node form_data_to_json.js > form-json.json` to get a json file with the updated question ids and values. This needs to be plugged into the backend in per/models.py

--- a/src/root/components/per-forms/form-data/form_data_to_json.js
+++ b/src/root/components/per-forms/form-data/form_data_to_json.js
@@ -1,4 +1,4 @@
-const fs = require('fs')
+const fs = require('fs');
 
 const forms = [
   'a1',
@@ -7,31 +7,31 @@ const forms = [
   'a3-2',
   'a4',
   'a5'
-]
+];
 
-const data = {}
+const data = {};
 
 forms.forEach(f => {
 
   // This is terrible code.
   // Converts the js files into JSON data that can be read into a variable
-  const txt = fs.readFileSync(`./${f}/english-data.js`, 'utf-8')
-  const json = txt.trim().replace('export const englishForm = ', '').slice(0, -1)
-  eval(`data[f] = ${json}`)
-})
+  const txt = fs.readFileSync(`./${f}/english-data.js`, 'utf-8');
+  const json = txt.trim().replace('export const englishForm = ', '').slice(0, -1);
+  eval(`data[f] = ${json}`);
+});
 
-const output = {}
+const output = {};
 
 forms.forEach(form => {
-  const components = data[form].components
+  const components = data[form].components;
   components.forEach((comp, compIdx) => {
     if (comp.namespaces) {
       comp.namespaces.forEach((ns, nsIdx) => {
-        const qid = `${form}c${compIdx}q${nsIdx}`
-        output[qid] = ns.nsTitle
-      })
+        const qid = `${form}c${compIdx}q${nsIdx}`;
+        output[qid] = ns.nsTitle;
+      });
     }
-  })  
-})
+  });  
+});
 
-console.log(JSON.stringify(output, null, 2))
+console.log(JSON.stringify(output, null, 2));

--- a/src/root/components/per-forms/form-data/form_data_to_json.js
+++ b/src/root/components/per-forms/form-data/form_data_to_json.js
@@ -1,0 +1,37 @@
+const fs = require('fs')
+
+const forms = [
+  'a1',
+  'a2',
+  'a3',
+  'a3-2',
+  'a4',
+  'a5'
+]
+
+const data = {}
+
+forms.forEach(f => {
+
+  // This is terrible code.
+  // Converts the js files into JSON data that can be read into a variable
+  const txt = fs.readFileSync(`./${f}/english-data.js`, 'utf-8')
+  const json = txt.trim().replace('export const englishForm = ', '').slice(0, -1)
+  eval(`data[f] = ${json}`)
+})
+
+const output = {}
+
+forms.forEach(form => {
+  const components = data[form].components
+  components.forEach((comp, compIdx) => {
+    if (comp.namespaces) {
+      comp.namespaces.forEach((ns, nsIdx) => {
+        const qid = `${form}c${compIdx}q${nsIdx}`
+        output[qid] = ns.nsTitle
+      })
+    }
+  })  
+})
+
+console.log(JSON.stringify(output, null, 2))


### PR DESCRIPTION
Adds a helper `node` script to re-generate a JSON for the PER questions, that can be plugged into the backend.

Refs #1137

cc @GregoryHorvath 