### PR TITLE
Fix language for activities in step 3

### DIFF
--- a/src/root/utils/field-report-constants.js
+++ b/src/root/utils/field-report-constants.js
@@ -538,7 +538,7 @@ export const fieldsStep1 = {
   'summary': {
     'EVT': {
       label: 'Title *',
-      desc: 'For Covid-19 Field Reports, please link to the country specific emergency page if one already exists. Please do not link to the Global emergency page.'
+      desc: 'For Covid-19 Field Reports, please link to the existing country specific emergency page. Please do not link to the Global emergency page.'
     },
     'EPI': {
       label: 'Title *',

--- a/src/root/utils/field-report-constants.js
+++ b/src/root/utils/field-report-constants.js
@@ -542,11 +542,11 @@ export const fieldsStep1 = {
     },
     'EPI': {
       label: 'Title *',
-      desc: 'For Covid-19 Field Reports, please link to the country specific emergency page if one already exists. Please do not link to the Global emergency page.'
+      desc: 'For Covid-19 Field Reports, please link to the existing country specific emergency page. Please do not link to the Global emergency page.'
     },
     'EW': {
       label: 'Title *',
-      desc: 'For Covid-19 Field Reports, please link to the country specific emergency page if one already exists. Please do not link to the Global emergency page.'
+      desc: 'For Covid-19 Field Reports, please link to the existing country specific emergency page. Please do not link to the Global emergency page.'
     }
   },
   'disaster-type': {
@@ -872,6 +872,7 @@ export const fieldsStep3 = {
       'desc': {
         'EVT': 'Select the activities undertaken by the National Society and briefly describe.',
         'EPI': 'Select the activities undertaken by the National Society and briefly describe.',
+        'EPI-COV': 'Select the activities undertaken by the National Society and briefly describe.',
         'EW': 'Select the early action activities undertaken by the National Society and give a brief description'
       },
       'placeholder': {
@@ -892,6 +893,7 @@ export const fieldsStep3 = {
       'desc': {
         'EVT': 'Select the activities taken by the IFRC (could be the Regional office, cluster office or country office) and briefly describe.',
         'EPI': 'Select the activities taken by the IFRC (could be the Regional office, cluster office or country office) and briefly describe.',
+        'EPI-COV': 'Describe the activities taken by the IFRC (could be the Regional office, cluster office or country office)',
         'EW': 'Select the early action activities undertaken by the IFRC and give a brief description'
       },
       'placeholder': {
@@ -912,6 +914,7 @@ export const fieldsStep3 = {
       'desc': {
         'EVT': 'Select the activities undertaken by any other RCRC Movement actor(s) and briefly describe.',
         'EPI': 'Select the activities undertaken by any other RCRC Movement actor(s) and briefly describe.',
+        'EPI-COV': 'Describe the activities undertaken by any other RCRC Movement actor(s)',
         'EW': 'Select the early action activities undertaken by the RCRC Movement and give a brief description.'
       },
       'placeholder': {

--- a/src/root/views/field-report-form/index.js
+++ b/src/root/views/field-report-form/index.js
@@ -718,10 +718,12 @@ class FieldReportForm extends React.Component {
               });
               values.options = sectionValues;
 
+              const description = this.state.data.isCovidReport === 'true' ? section.desc[status + '-COV'] : section.desc[status];
+
               return (
                 <ActionsCheckboxes
                   label={section.label[status]}
-                  description={section.desc[status]}
+                  description={description}
                   placeholder={section.placeholder[status]}
                   name={section.name}
                   key={section.key}


### PR DESCRIPTION
Link: #1226 

- Fixes title help text 
- Fixes help text for two activity sections

<img width="1177" alt="image" src="https://user-images.githubusercontent.com/719357/82283540-aad3ad80-9964-11ea-867e-ea0aa1b83123.png">

---

<img width="1177" alt="image" src="https://user-images.githubusercontent.com/719357/82283568-c0e16e00-9964-11ea-8e02-08f1b1c390fe.png">



Surge: https://ifrc-go-fix-1226-fix-covid-language.surge.sh