### PR TITLE
Remove header from tabs on emergency page

### DIFF
--- a/src/root/components/emergencies/snippets.js
+++ b/src/root/components/emergencies/snippets.js
@@ -19,7 +19,7 @@ class Snippets extends Component {
 
     return (
       <TabContent showError={true} isError={!get(data, 'results.length')} errorMessage={ NO_DATA } title="Additional Graphics">
-        <Fold id='graphics' title='Additional Graphics' wrapper_class='additional-graphics'>
+        <Fold id='graphics' showHeader={false} title='Additional Graphics' wrapper_class='additional-graphics'>
           <div className='iframe__container'>
             {data.results.map(o => o.snippet ? <div className='snippet__item' key={o.id} dangerouslySetInnerHTML={{__html: o.snippet}} />
               : o.image ? <div key={o.id} className='snippet__item snippet__image'><img src={o.image}/></div> : null


### PR DESCRIPTION
Link: #1232 
Surge: https://ifrc-go-fix-1232-remove-additional-graphics.surge.sh