### PR TITLE
Disable disaster type from the start

### DIFF
--- a/src/root/views/field-report-form/index.js
+++ b/src/root/views/field-report-form/index.js
@@ -450,7 +450,7 @@ class FieldReportForm extends React.Component {
               placeholder='Select a disaster type'
               name='disaster-type'
               id='disaster-type'
-              disabled={ this.state.data.isCovidReport === 'true' }
+              disabled={ this.state.data.isCovidReport === 'true' || !this.state.data.isCovidReport }
               options={formData.disasterType}
               value={this.state.data.disasterType}
               onChange={({value}) => this.onFieldChange('disasterType', value)}


### PR DESCRIPTION
Missed to handle the 'Disaster type' field with the previous changes to fields being disabled by the start of creating a Field Report.