### PR TITLE
Allow public FRs on emergency pages

### DIFF
--- a/src/root/views/emergency.js
+++ b/src/root/views/emergency.js
@@ -172,14 +172,6 @@ class Emergency extends React.Component {
     return false;
   }
 
-  renderMustLogin () {
-    return (
-      <React.Fragment>
-        <p>You must be logged in to view this. <Link key='login' to={{ pathname: '/login', state: { from: this.props.location } }} className='link--primary' title='Login'>Login</Link></p>
-      </React.Fragment>
-    );
-  }
-
   renderFieldReportStatsEW (report) {
     const numPotentiallyAffected = parseInt(get(report, 'num_potentially_affected')) || parseInt(get(report, 'gov_num_potentially_affected')) || parseInt(get(report, 'other_num_potentially_affected'));
     const numHighestRisk = parseInt(get(report, 'num_highest_risk')) || parseInt(get(report, 'gov_num_highest_risk')) || parseInt(get(report, 'other_num_highest_risk'));
@@ -347,13 +339,7 @@ class Emergency extends React.Component {
 
   renderFieldReports () {
     const { data } = this.props.event;
-    if (!this.props.isLogged) {
-      return (
-        <Fold id='field-reports' title='Field Reports' wrapperClass='event-field-reports' >
-          {this.renderMustLogin()}
-        </Fold>
-      );
-    } else if (data.field_reports && data.field_reports.length) {
+    if (data.field_reports && data.field_reports.length) {
       return (
         <Fold id='field-reports' title={`Field Reports (${data.field_reports.length})`} wrapperClass='event-field-reports' >
           <table className='table table--zebra'>


### PR DESCRIPTION
To complete #1118 we need to be able to see public FRs on emergency pages in the "Field Reports" tab. I removed the "must login" logic, but I didn't know how to associate two FRs to one emergency to see what happens when there is a private FR as well as a public FR. Could you test @batpad @karitotp ?

https://ifrc-go-fix-1118-emergency-pages.surge.sh/emergencies/3833#details