### PR TITLE
hide field reports on emergency page based on user permissions

### DIFF
--- a/src/root/views/emergency.js
+++ b/src/root/views/emergency.js
@@ -339,7 +339,7 @@ class Emergency extends React.Component {
 
   userHasPerms (fieldReport) {
     const userIsAnon = !this.props.isLogged;
-    const userIsSuperuser = this.props.profile.fetched && this.props.profile.data.email.endsWith('ifrc.org');
+    const userIsSuperuser = this.props.profile.fetched && this.props.profile.data.is_superuser;
     const visibility = fieldReport.visibility;
 
     // superusers can see all reports

--- a/src/root/views/emergency.js
+++ b/src/root/views/emergency.js
@@ -359,9 +359,6 @@ class Emergency extends React.Component {
 
   renderFieldReports () {
     const { data } = this.props.event;
-    console.log('field reports', data.field_reports);
-    console.log('user', this.props.user);
-    console.log('profile', this.props.profile);
 
     if (data.field_reports && data.field_reports.length) {
       return (

--- a/src/root/views/emergency.js
+++ b/src/root/views/emergency.js
@@ -48,7 +48,6 @@ import EmergencyMap from '../components/map/emergency-map';
 import { NO_DATA } from '../utils/constants';
 import { epiSources } from '../utils/field-report-constants';
 import ProjectFormModal from './ThreeW/project-form-modal';
-import { throws } from 'assert';
 
 class Emergency extends React.Component {
   constructor (props) {

--- a/src/root/views/emergency.js
+++ b/src/root/views/emergency.js
@@ -359,8 +359,8 @@ class Emergency extends React.Component {
 
   renderFieldReports () {
     const { data } = this.props.event;
-
-    if (data.field_reports && data.field_reports.length) {
+    const fieldReports = data.field_reports ? data.field_reports.filter(fr => this.userHasPerms(fr)) : [];
+    if (fieldReports.length) {
       return (
         <Fold id='field-reports' title={`Field Reports (${data.field_reports.length})`} wrapperClass='event-field-reports' >
           <table className='table table--zebra'>
@@ -373,7 +373,7 @@ class Emergency extends React.Component {
               </tr>
             </thead>
             <tbody>
-              {data.field_reports.map(o => this.userHasPerms(o) ? (
+              {fieldReports.map(o => (
                 <tr key={o.id}>
                   <td>{isoDate(o.created_at)}</td>
                   <td><Link to={`/reports/${o.id}`} className='link--primary' title='View Field Report'>{o.summary || noSummary}</Link></td>
@@ -388,7 +388,7 @@ class Emergency extends React.Component {
                     )) : nope}
                   </td>
                 </tr>
-              ) : null)}
+              ))}
             </tbody>
           </table>
         </Fold>

--- a/src/root/views/emergency.js
+++ b/src/root/views/emergency.js
@@ -48,6 +48,7 @@ import EmergencyMap from '../components/map/emergency-map';
 import { NO_DATA } from '../utils/constants';
 import { epiSources } from '../utils/field-report-constants';
 import ProjectFormModal from './ThreeW/project-form-modal';
+import { throws } from 'assert';
 
 class Emergency extends React.Component {
   constructor (props) {
@@ -337,8 +338,31 @@ class Emergency extends React.Component {
     );
   }
 
+  userHasPerms (fieldReport) {
+    const userIsAnon = !this.props.isLogged;
+    const userIsSuperuser = this.props.profile.fetched && this.props.profile.data.email.endsWith('ifrc.org');
+    const visibility = fieldReport.visibility;
+
+    // superusers can see all reports
+    if (userIsSuperuser) {
+      return true;
+    }
+
+    // anonymous users can only see public reports
+    if (userIsAnon) {
+      return visibility === '1';
+    }
+
+    // logged in users can see all reports not restricted to IFRC
+    return visibility !== '3';
+  }
+
   renderFieldReports () {
     const { data } = this.props.event;
+    console.log('field reports', data.field_reports);
+    console.log('user', this.props.user);
+    console.log('profile', this.props.profile);
+
     if (data.field_reports && data.field_reports.length) {
       return (
         <Fold id='field-reports' title={`Field Reports (${data.field_reports.length})`} wrapperClass='event-field-reports' >
@@ -352,7 +376,7 @@ class Emergency extends React.Component {
               </tr>
             </thead>
             <tbody>
-              {data.field_reports.map(o => (
+              {data.field_reports.map(o => this.userHasPerms(o) ? (
                 <tr key={o.id}>
                   <td>{isoDate(o.created_at)}</td>
                   <td><Link to={`/reports/${o.id}`} className='link--primary' title='View Field Report'>{o.summary || noSummary}</Link></td>
@@ -367,7 +391,7 @@ class Emergency extends React.Component {
                     )) : nope}
                   </td>
                 </tr>
-              ))}
+              ) : null)}
             </tbody>
           </table>
         </Fold>

--- a/src/root/views/emergency.js
+++ b/src/root/views/emergency.js
@@ -349,11 +349,11 @@ class Emergency extends React.Component {
 
     // anonymous users can only see public reports
     if (userIsAnon) {
-      return visibility === '1';
+      return visibility === 1;
     }
 
     // logged in users can see all reports not restricted to IFRC
-    return visibility !== '3';
+    return visibility !== 3;
   }
 
   renderFieldReports () {


### PR DESCRIPTION
This should fix the frontend component to this ticket comment: https://github.com/IFRCGo/go-frontend/issues/1118#issuecomment-635918910

Is dependent on changes to the backend. @GregoryHorvath will be great if you could test this locally with the backend changes, or deploy the backend to staging and we can test this. Thanks!