### PR TITLE
Increase Elasticsearch setTimeout

### DIFF
--- a/src/root/components/header.js
+++ b/src/root/components/header.js
@@ -49,7 +49,7 @@ class Header extends React.PureComponent {
           } else {
             return resolve({ options: [] });
           }
-        }, 150);
+        }, 500);
       });
     };
   }


### PR DESCRIPTION
Increased the frequency when Elasticsearch is picking up the input into the searchbox from `150ms` -> `500ms`. It feels like a reasonabe middle ground for both fast- and slow-typers.

Should help a bit with: https://github.com/IFRCGo/go-frontend/issues/989 