### PR TITLE
Error message fix for Create Field Report form

### DIFF
--- a/src/root/views/field-report-form/index.js
+++ b/src/root/views/field-report-form/index.js
@@ -95,7 +95,10 @@ class FieldReportForm extends React.Component {
     if (this.props.fieldReportForm.fetching && !nextProps.fieldReportForm.fetching) {
       hideGlobalLoading();
       if (nextProps.fieldReportForm.error) {
-        const message = nextProps.fieldReportForm.error.error_message || nextProps.fieldReportForm.error.detail || 'Could not submit field report';
+        const message = nextProps.fieldReportForm.error.error_message
+          || nextProps.fieldReportForm.error.detail
+          || nextProps.fieldReportForm.error[Object.keys(nextProps.fieldReportForm.error)[0]][0] // first key's value
+          || 'Could not submit field report';
         showAlert('danger', <p><strong>Error:</strong> {message}</p>, true, 4500);
       } else {
         const { history } = this.props;


### PR DESCRIPTION
## Changes
`nextProps.fieldReportForm.error` object could have a key like `start_date` if that field has an error, so it wouldn't be good to list all fields here. With this basically it doesn't matter how many fields may have errors it will only display the first and if that's fixed it will show the second (if there is), etc.

This only affects the submission errors, the errors happening at record creation should already say the error was.

cc @teklal 