### PR TITLE
fix breadcrumbs on table views without filters

### DIFF
--- a/src/root/views/table.js
+++ b/src/root/views/table.js
@@ -91,7 +91,10 @@ class Table extends React.Component {
     const isEmptyQS = Object.keys(qs).length === 0;
     const extraCrumbs = [];
     if (isEmptyQS) {
-      extraCrumbs.push(`All ${tableType}`);
+      extraCrumbs.push({
+        link: this.props.location.pathname,
+        name: `All ${tableType}`
+      });
     } else {
       extraCrumbs.push({
         link: this.props.location.pathname,
@@ -118,6 +121,7 @@ class Table extends React.Component {
 
   render () {
     const crumbs = this.getCrumbs();
+    console.log('crumbs', crumbs);
     return (
       <App>
         <Helmet>

--- a/src/root/views/table.js
+++ b/src/root/views/table.js
@@ -121,7 +121,6 @@ class Table extends React.Component {
 
   render () {
     const crumbs = this.getCrumbs();
-    console.log('crumbs', crumbs);
     return (
       <App>
         <Helmet>


### PR DESCRIPTION
Fixes a silly error causing the breadcrumbs to be broken on the `All emergencies` and `All operations` pages.

cc @GregoryHorvath 