### PR TITLE
add release note for backend hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Release 4.3.8
+
+Hotfix Release (only an API release): Fix regression in CSV exports where ENUM fields were showing verbose labels instead of db values: https://github.com/IFRCGo/go-api/pull/794
+
 ### Release 4.3.7
 
 Hotfix release: fixes broken breadcrumbs on tabular views without filters - i.e. All Emergencies, All Operations, etc.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "go-frontend",
-  "version": "4.3.7",
+  "version": "4.3.8",
   "private": true,
   "devDependencies": {
     "@babel/core": "7.9.0",


### PR DESCRIPTION
Just added a quick release note for the backend release -- it's a bit awkward since we are not doing a corresponding frontend release for this hotfix, but is likely useful to have this release note.