### PR TITLE
Move highlighted ops below Key Figures on home-page

### DIFF
--- a/src/root/components/common/key-figures-header.js
+++ b/src/root/components/common/key-figures-header.js
@@ -102,7 +102,7 @@ export default function KeyFiguresHeader (props) {
   };
 
   return (
-    <div className='inner row'>
+    <div className='inner row stats-overall-row'>
       {props.fullscreen ? (
         <FullscreenHeader title={strings.keyFiguresHeading}/>
       ) : null}

--- a/src/root/components/connected/presentation-dash.js
+++ b/src/root/components/connected/presentation-dash.js
@@ -66,7 +66,7 @@ class PresentationDash extends React.Component {
           fullscreen={this.state.fullscreen}
           toggleFullscreen={this.toggleFullscreen}
         />
-        <HighlightedOperations opsType='all'/>
+        { !this.state.fullscreen ? (<HighlightedOperations opsType='all'/>) : null }
         <div className={c('inner', {'appeals--fullscreen': this.state.fullscreen})}>
           <AppealsTable
             showActive={true}

--- a/src/root/components/connected/presentation-dash.js
+++ b/src/root/components/connected/presentation-dash.js
@@ -14,6 +14,7 @@ import {
 } from '#utils/fullscreen';
 
 import KeyFiguresHeader from '#components/common/key-figures-header';
+import HighlightedOperations from '#components/highlighted-operations';
 
 import TimelineCharts from '#components/timeline-charts';
 import AppealsTable from '#components/connected/appeals-table';
@@ -65,6 +66,7 @@ class PresentationDash extends React.Component {
           fullscreen={this.state.fullscreen}
           toggleFullscreen={this.toggleFullscreen}
         />
+        <HighlightedOperations opsType='all'/>
         <div className={c('inner', {'appeals--fullscreen': this.state.fullscreen})}>
           <AppealsTable
             showActive={true}

--- a/src/root/views/home.js
+++ b/src/root/views/home.js
@@ -3,7 +3,6 @@ import { Helmet } from 'react-helmet';
 import App from './app';
 import PresentationDash from '#components/connected/presentation-dash';
 import AlertsTable from '#components/connected/alerts-table';
-import HighlightedOperations from '#components/highlighted-operations';
 
 import LanguageContext from '#root/languageContext';
 import Translate from '#components/Translate';
@@ -31,7 +30,6 @@ class Home extends React.Component {
             </div>
           </header>
           <div className='inpage__body inpage__body__main'>
-            <HighlightedOperations opsType='all'/>
             <div className='inner'>
               <AlertsTable
                 title={strings.homeSurgeNotification}

--- a/src/styles/home/_global.scss
+++ b/src/styles/home/_global.scss
@@ -804,3 +804,9 @@
     height: 16px;
   }
 }
+
+.stats-overall-row {
+  max-width: 1200px !important;
+  margin-left: auto;
+  margin-right: auto;
+}


### PR DESCRIPTION
Addresses #1376 

@imohkay moved highlighted ops below key figures and also handles hiding Highlighted Ops on full-screen so it doesn't interfere with Presentation mode.

If this looks okay to you, let's merge to develop.