### PR TITLE
hide pagination if there is only 1 page of results, across all tables #1418

### DIFF
--- a/src/root/components/display-table.js
+++ b/src/root/components/display-table.js
@@ -44,7 +44,7 @@ export default class DisplayTable extends React.Component {
   }
 
   renderPagination () {
-    if (this.props.rows.length && !this.props.noPaginate) {
+    if (this.props.rows.length && !this.props.noPaginate && this.props.pageCount > 1) {
       return (
         <div className='pagination-wrapper pagination-wrapper--table'>
           <ReactPaginate


### PR DESCRIPTION
As per #1418, hide pagination if there is only 1 page.

@imohkay could you check this and merge?