### PR TITLE
#1429 - move table heading on emergencies page to above map (pending …

### DIFF
--- a/src/root/components/connected/emergencies-dash.js
+++ b/src/root/components/connected/emergencies-dash.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { PropTypes as T } from 'prop-types';
 import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip } from 'recharts';
 import { DateTime } from 'luxon';
-
+import { Link } from 'react-router-dom';
 import { environment } from '#config';
 import Stats from '#components/emergencies/stats';
 import EmergenciesMap from '#components/map/emergencies-map';
@@ -143,6 +143,12 @@ class EmergenciesDash extends React.Component {
           </div>
         </header>
         <section className='map-section__container'>
+          <h1>
+            { this.props.title }
+          </h1>
+          <Link to='/emergencies/all'>
+            View All Emergencies
+          </Link>
           <EmergenciesMap lastMonth={lastMonth} />
         </section>
       </div>

--- a/src/root/components/connected/emergencies-dash.js
+++ b/src/root/components/connected/emergencies-dash.js
@@ -143,12 +143,19 @@ class EmergenciesDash extends React.Component {
           </div>
         </header>
         <section className='map-section__container'>
-          <h1>
-            { this.props.title }
-          </h1>
-          <Link to='/emergencies/all'>
-            View All Emergencies
-          </Link>
+          <div className='fold padding-top-reset spacing-b'>
+            <div className='container-lg'>
+              <div className='fold__header__block'>
+                <h2 className='fold__title'>{ this.props.title }</h2>
+                <div className="fold__title__linkwrap">
+                  <Link to='/emergencies/all' className='fold__title__link'>
+                    View All Emergencies
+                    <span className="collecticon-chevron-right"></span>
+                  </Link>
+                </div>
+              </div>
+            </div>
+          </div>
           <EmergenciesMap lastMonth={lastMonth} />
         </section>
       </div>

--- a/src/root/components/connected/emergencies-table.js
+++ b/src/root/components/connected/emergencies-table.js
@@ -209,7 +209,14 @@ class EmergenciesTable extends SFPComponent {
 
       const foldLink = this.props.viewAll ? (<Link className='fold__title__link' to={this.props.viewAll}>{this.props.viewAllText || strings.emergenciesTableViewAll}</Link>) : null;
       return (
-        <Fold foldWrapperClass='fold--main spacing-half-t' foldTitleClass='fold__title--inline margin-reset' navLink={foldLink} title={`${title} (${n(data.count)})`} id={this.props.id}>
+        <Fold 
+          foldWrapperClass='fold--main spacing-half-t'
+          foldTitleClass='fold__title--inline margin-reset'
+          navLink={foldLink}
+          title={`${title} (${n(data.count)})`}
+          id={this.props.id}
+          showHeader={this.props.showHeader ? this.props.showHeader : false}
+        >
           {this.props.showExport ? (
             <ExportButton filename='emergencies'
               qs={this.getQs(this.props)}
@@ -244,6 +251,7 @@ if (environment !== 'production') {
 
     noPaginate: T.bool,
     showExport: T.bool,
+    showHeader: T.bool,
     title: T.string,
 
     showRecent: T.bool,

--- a/src/root/views/emergencies.js
+++ b/src/root/views/emergencies.js
@@ -4,7 +4,7 @@ import { DateTime } from 'luxon';
 import { PropTypes as T } from 'prop-types';
 import { Helmet } from 'react-helmet';
 import BreadCrumb from '../components/breadcrumb';
-
+import BlockLoading from '#components/block-loading';
 import App from './app';
 import FieldReportsTable from '#components/connected/field-reports-table';
 import EmergenciesDash from '#components/connected/emergencies-dash';
@@ -23,6 +23,13 @@ class Emergencies extends React.Component {
 
   render () {
     const { strings } = this.context;
+    if (!this.props.lastMonth.fetched) {
+      return (
+        <BlockLoading />
+      );
+    }
+    const count = this.props.lastMonth.data.count;
+    const dashTitle = `${strings.emergenciesTitle} (${count})`;
     return (
       <App className='page--emergencies'>
         <Helmet>
@@ -32,14 +39,16 @@ class Emergencies extends React.Component {
         </Helmet>
         <section className='inpage'>
           <BreadCrumb crumbs={[{link: '/emergencies', name: 'Emergencies'}, {link: '/', name: strings.breadCrumbHome }]} />
-          <EmergenciesDash />
+          <EmergenciesDash 
+            title={dashTitle}
+          />
           <div>
             <div className='inner'>
               <EmergenciesTable
                 title={strings.emergenciesTableTitle}
                 limit={10}
-                viewAll={'/emergencies/all'}
                 showRecent={true}
+                showHeader={false}
               />
             </div>
             <div className='inner inner--field-reports-emergencies'>


### PR DESCRIPTION
Addresses #1429 

@imohkay I didn't do any styling, could you please push a fix to the styling and then we can merge this into the `grid-ui` branch.