### PR TITLE
Removed duplicate getAppealsList call

### DIFF
--- a/src/root/components/connected/presentation-dash.js
+++ b/src/root/components/connected/presentation-dash.js
@@ -34,8 +34,6 @@ class PresentationDash extends React.Component {
 
   componentDidMount () {
     addFullscreenListener(this.onFullscreenChange);
-
-    this.props._getAppealsList();
   }
 
   componentWillUnmount () {


### PR DESCRIPTION
Ref.: https://github.com/IFRCGo/go-frontend/issues/1443

The home page fired some duplicate requests. The `AppealsTable` component already has the necessary action:
https://github.com/IFRCGo/go-frontend/blob/22407768ad312dfbc51546ecc978ce7ba87f276e/src/root/components/connected/appeals-table.js#L54