### PR TITLE
dont crash emergency page if region for country is null

### DIFF
--- a/src/root/views/emergency.js
+++ b/src/root/views/emergency.js
@@ -795,8 +795,11 @@ class Emergency extends React.Component {
     const countryLink = `/countries/${this.props.event.data.countries[0].id}`;
     const countryName = data.countries[0].name;
     const regionId = this.props.event.data.countries[0].region;
-    const regionLink = `/regions/${regionId}`;
-    const regionName = getRegionById(regionId.toString()).name;
+    let regionLink, regionName;
+    if (regionId) {
+      regionLink = `/regions/${regionId}`;
+      regionName = getRegionById(regionId.toString()).name;
+    }
 
     return (
       <section className="inpage">
@@ -871,16 +874,18 @@ class Emergency extends React.Component {
               <div className="inpage__headline-content">
                 <h1 className="inpage__title">{data.name}</h1>
                 <div className="inpage__headline-actions row flex flex-justify-center">
-                  <div className='col spacing-half-v flex'>
-                    <Link to={regionLink}
-                      className="link link--with-icon"
-                    >
-                      <span className='link--with-icon-text'>
-                        {regionName}
-                      </span>
-                      <span className='collecticon-chevron-right link--with-icon-inner'></span>
-                    </Link>
-                  </div>
+                  { regionId ? (
+                    <div className='col spacing-half-v flex'>
+                      <Link to={regionLink}
+                        className="link link--with-icon"
+                      >
+                        <span className='link--with-icon-text'>
+                          {regionName}
+                        </span>
+                        <span className='collecticon-chevron-right link--with-icon-inner'></span>
+                      </Link>
+                    </div>
+                  ) : null }
                   <div className='col spacing-half-v flex'>
                     <Link to={countryLink}
                       className="link link--with-icon"


### PR DESCRIPTION
Addresses #1451 - I did not realize there are some cases where the `region` for the country is `null`. Ideally this will be fixed in the data with the new geospatial fixes, for now, working around in code and not displaying the "Region" identifier below the title when region is null.