### PR TITLE
hide link to region below country title on country page if region is null

### DIFF
--- a/src/root/views/countries.js
+++ b/src/root/views/countries.js
@@ -651,6 +651,7 @@ class AdminArea extends SFPComponent {
                 </span>
               ) : null}
             </h1>
+            { region ? (
             <div className='inpage__header-actions text-center'>
               <div className='spacing-half-v'>
                 <Link to={`/regions/${data.region}`}
@@ -660,7 +661,8 @@ class AdminArea extends SFPComponent {
                   <span className='collecticon-chevron-right link--with-icon-inner'></span>
                 </Link>
               </div>
-            </div>
+            </div>) : null }
+
           </div>
         </header>
         <section className='inpage__body'>


### PR DESCRIPTION
Fixes crash on country page if region for country is null.