### PR TITLE
#1469: fix for action button height on specific emergency page

### DIFF
--- a/src/styles/emergency/_global.scss
+++ b/src/styles/emergency/_global.scss
@@ -256,11 +256,9 @@ h2.map__container__title {
 }
 
 .button--edit-action {
-  &.button .collecticon-pencil::before {
+  
+  &.button [class^="collecticon-"] {
     font-size: 0.8rem !important;
-    position: relative;
-    top: -2px;
-    height: 24px; //TODO FIX
   }
 }
 


### PR DESCRIPTION
Related to #1469 