### PR TITLE
Re-send validation email

### DIFF
--- a/src/root/Multiplexer/index.js
+++ b/src/root/Multiplexer/index.js
@@ -21,6 +21,7 @@ import Login from '#views/login';
 import Register from '#views/register';
 import RecoverAccount from '#views/recover-account';
 import RecoverUsername from '#views/recover-username';
+import ResendValidation from '#views/resend-validation';
 import UhOh from '#views/uhoh';
 import FieldReportForm from '#views/field-report-form/';
 import FieldReport from '#views/field-report';
@@ -88,6 +89,7 @@ function Multiplexer(props) {
           <AnonymousRoute exact path='/recover-account' component={RecoverAccount}/>
           <AnonymousRoute exact path='/recover-account/:username/:token' component={RecoverAccount}/>
           <AnonymousRoute exact path='/recover-username' component={RecoverUsername}/>
+          <AnonymousRoute exact path='/resend-validation' component={ResendValidation} />
           <PrivateRoute exact path='/reports/new' component={FieldReportForm}/>
           <Route exact path='/reports/all' render={props => <Table {...props} type='report' />} />
           <PrivateRoute exact path='/reports/:id/edit' component={FieldReportForm}/>

--- a/src/root/actions/index.js
+++ b/src/root/actions/index.js
@@ -53,6 +53,11 @@ export function showUsername (email) {
   return postJSON('show_username', SHOW_USERNAME, { email });
 }
 
+export const RESEND_VALIDATION = 'RESEND_VALIDATION';
+export function resendValidation (username) {
+  return postJSON('resend_validation', RESEND_VALIDATION, { username });
+}
+
 export const GET_ME = 'GET_ME';
 export const getMe = () => (
   fetchJSON('api/v2/user/me/', GET_ME, withToken())

--- a/src/root/lang.js
+++ b/src/root/lang.js
@@ -106,10 +106,12 @@ export default {
   loginForgotPassword: 'I forgot my password.',
   loginShowUsernameTitle: 'Show me my username',
   loginForgotUsername: 'I forgot my username only.',
+  loginResendValidation: 'Re-send validation email.',
+  loginResendValidationTitle: 'I didn\'t get my validation email',
   loginInvalid: 'Invalid username or password',
   loginErrorMessage: 'Error: {message}',
   loginButton: 'Login',
-  loginDontHaveAccount: 'Don’t have an account?',
+  loginDontHaveAccount: 'Don’t have an account? ',
   loginCreateAccountTitle: 'Create new account',
   loginSignUp: 'Sign Up.',
 
@@ -225,6 +227,11 @@ export default {
   recoverUsernameEmail: 'Enter the email you used during registration',
   recoverUsernameEmailLabel: 'Email',
   recoverUsernameSubmitText: 'Send me my username',
+
+  resendValidationTitle: 'IFRC Go - Re-send Validation Email',
+  resendValidationUsername: 'Enter the username you used during registration',
+  resendValidationUsernameLabel: 'Username',
+  resendValidationSubmitText: 'Re-send',
 
   presentationDashAppealsTitle: 'Active Operations',
 

--- a/src/root/reducers/index.js
+++ b/src/root/reducers/index.js
@@ -18,6 +18,7 @@ import event from './event';
 import adminArea from './admin-area';
 import eruOwners from './eru-owners';
 import heops from './heops';
+import resendValidation from './resend-validation';
 import registration from './registration';
 import password from './password';
 import email from './email';
@@ -63,6 +64,7 @@ export const reducers = {
   adminArea,
   eruOwners,
   heops,
+  resendValidation,
   registration,
   appeals,
   password,

--- a/src/root/reducers/resend-validation.js
+++ b/src/root/reducers/resend-validation.js
@@ -1,0 +1,25 @@
+import { stateInflight, stateError, stateSuccess } from '#utils/reducer-utils';
+
+const initialState = {
+  fetching: false,
+  fetched: false,
+  receivedAt: null,
+  data: {}
+};
+
+function resendValidation (state = initialState, action) {
+  switch (action.type) {
+    case 'RESEND_VALIDATION_INFLIGHT':
+      state = stateInflight(state, action);
+      break;
+    case 'RESEND_VALIDATION_FAILED':
+      state = stateError(state, action);
+      break;
+    case 'RESEND_VALIDATION_SUCCESS':
+      state = stateSuccess(state, action);
+      break;
+  }
+  return state;
+}
+
+export default resendValidation;

--- a/src/root/views/login.js
+++ b/src/root/views/login.js
@@ -137,6 +137,8 @@ class Login extends React.Component {
                     <Link to='/recover-account' title={strings.loginRecoverTitle}><span><Translate stringId='loginForgotPassword' /></span></Link>
                     <br/>
                     <Link to='/recover-username' title={strings.loginShowUsernameTitle}><span><Translate stringId='loginForgotUsername' /></span></Link>
+                    <br/>
+                    <Link to='/resend-validation' title={strings.loginResendValidationTitle}><span><Translate stringId='loginResendValidation' /></span></Link>
                   </p>
                 </FormInput>
 

--- a/src/root/views/resend-validation.js
+++ b/src/root/views/resend-validation.js
@@ -1,0 +1,142 @@
+import React from 'react';
+import c from 'classnames';
+import { connect } from 'react-redux';
+import { PropTypes as T } from 'prop-types';
+import { Helmet } from 'react-helmet';
+
+import { environment } from '#config';
+
+import App from './app';
+import { resendValidation } from '#actions';
+import { FormInput, FormError } from '#components/form-elements/';
+import { showAlert } from '#components/system-alerts';
+import { showGlobalLoading, hideGlobalLoading } from '#components/global-loading';
+
+import LanguageContext from '#root/languageContext';
+import Translate from '#components/Translate';
+
+class ResendValidation extends React.Component {
+  constructor (props) {
+    super(props);
+    const { params } = this.props.match;
+    const hasTokens = params.username && params.token;
+    this.state = {
+      data: {
+        username: ''
+      },
+      errors: null,
+      hasTokens
+    };
+    this.onSubmit = this.onSubmit.bind(this);
+  }
+
+  // eslint-disable-next-line camelcase
+  UNSAFE_componentWillReceiveProps (nextProps) {
+    if (this.state.hasTokens) { return; }
+    hideGlobalLoading();
+    if (nextProps.resendValidation.fetched) {
+      if (nextProps.resendValidation.error) {   
+        showAlert('danger', <p><strong>Error:</strong> {nextProps.resendValidation.error.error_message}</p>, true, 7000);
+      } else {
+        showAlert('success', <p>We've sent an email to your inbox. Redirecting...</p>, true, 2000);
+        setTimeout(() => this.props.history.push('/login'), 2000);
+      }
+    }
+  }
+
+  onSubmit (e) {
+    e.preventDefault();
+    const errors = this.state.data.username
+      ? null
+      : [{ dataPath: '.username', message: 'Please provide your username' }];
+    this.setState({ errors });
+    if (errors === null) {
+      showGlobalLoading();
+      this.props._resendValidation(this.state.data.username);
+    }
+  }
+
+  onFieldChange (field, e) {
+    let data = Object.assign({}, this.state.data, {[field]: e.target.value});
+    this.setState({data});
+  }
+
+  renderUsernameForm () {
+    const { strings } = this.context;
+    return (
+      <form className='form form--centered' onSubmit={this.onSubmit}>
+        <p className='form__note'>
+          <Translate stringId='resendValidationUsername' />
+        </p>
+        <FormInput
+          label={strings.resendValidationUsernameLabel}
+          type='text'
+          name='username'
+          id='username'
+          value={this.state.data.username}
+          onChange={this.onFieldChange.bind(this, 'username')}
+          autoFocus
+        >
+          <FormError
+            errors={this.state.errors}
+            property='username'
+          />
+        </FormInput>
+        <button className={c('mfa-tick', { disabled: !this.state.data.username })} type='button' onClick={this.onSubmit}>
+          <span>
+            <Translate stringId='resendValidationSubmitText' />
+          </span>
+        </button>
+      </form>
+    );
+  }
+
+  render () {
+    const { strings } = this.context;
+    return (
+      <App className='page--login'>
+        <Helmet>
+          <title>
+            {strings.resendValidationTitle}
+          </title>
+        </Helmet>
+        <section className='inpage container-lg'>
+          <header className='inpage__header'>
+            <div className='inner'>
+              <div className='inpage__headline'>
+                <h1 className='inpage__title'>
+                  <Translate stringId='recoverAccountHeading' />
+                </h1>
+              </div>
+            </div>
+          </header>
+          <div className='inpage__body'>
+            <div className='inner'>
+              {this.state.hasTokens ? null : this.renderUsernameForm()}
+            </div>
+          </div>
+        </section>
+      </App>
+    );
+  }
+}
+
+if (environment !== 'production') {
+  ResendValidation.propTypes = {
+    history: T.object,
+    match: T.object,
+    resendValidation: T.object,
+    _resendValidation: T.func
+  };
+}
+const selector = (state) => ({
+  username: state.username,
+  resendValidation: state.resendValidation
+});
+
+const dispatcher = (dispatch) => ({
+  _resendValidation: (username) => dispatch(resendValidation(username))
+});
+
+ResendValidation.contextType = LanguageContext;
+export default connect(selector, dispatcher)(ResendValidation);


### PR DESCRIPTION
Ref.: https://github.com/IFRCGo/go-api/issues/737

## Changes
- Added action, reducer, route and view for being able to re-send the validation email if the user didn't get it
- Added this to the login page's "Forgot password" section
- Added the required translation strings

Backend PR: https://github.com/IFRCGo/go-api/pull/840