### PR TITLE
Fix/deployments rapid response width

### DIFF
--- a/src/styles/deployments/_global.scss
+++ b/src/styles/deployments/_global.scss
@@ -2,6 +2,10 @@
   .table__header--name, .table__cell--name {
     width: 158px;
   }  
+
+  .table__header--type, .table__cell--type {
+    width: 148px;
+  }
 }
 
 .readiness__container {


### PR DESCRIPTION
Relates to size of Type: Rapid Response Table Cell in the Deployed Personnel table. The content should now fit on 1 line instead of spilling over to two lines.

Relates to #1203 