### PR TITLE
Fix/1325 fr fixes

### DIFF
--- a/src/root/views/field-report-form/index.js
+++ b/src/root/views/field-report-form/index.js
@@ -918,9 +918,13 @@ class FieldReportForm extends React.Component {
           </React.Fragment>
         )}
 
-        <h2 className='fold__title fold__title--contact'>
-          <Translate stringId="fieldReportFormContactsTitle" />
-        </h2>
+        <div className='fold__header'>
+          <div className='fold__header__block'>
+            <h2 className='fold__title fold__title--contact'>
+              <Translate stringId="fieldReportFormContactsTitle" />
+            </h2>
+          </div>
+        </div>
 
         <React.Fragment>
           {

--- a/src/root/views/field-report-form/index.js
+++ b/src/root/views/field-report-form/index.js
@@ -888,7 +888,6 @@ class FieldReportForm extends React.Component {
               <Translate stringId="fieldReportFormResponseLabel" />
             </label>
             <div className='form__description'>
-              <Translate stringId="fieldReportFormResponseLabel" />
               <p>
                 <Translate stringId="fieldReportFormResponseDescription" />
               </p>

--- a/src/root/views/field-report-form/index.js
+++ b/src/root/views/field-report-form/index.js
@@ -765,8 +765,7 @@ class FieldReportForm extends React.Component {
     // Note: There's no need for validation on this step.
     // All the fields are optional, and the text fields are just strings.
     return (
-      <Fold title=<Translate stringId="fieldReportFormContactsTitle" /> foldWrapperClass='fold--main fold--transparent'>
-      {/*<Fold title={strings.fieldReportFormActionTakenTitle}>*/}
+      <Fold title={strings.fieldReportFormActionTakenTitle} foldWrapperClass='fold--main fold--transparent'>
  
         <div className='form__group row flex-mid'>
           {
@@ -920,9 +919,9 @@ class FieldReportForm extends React.Component {
           </React.Fragment>
         )}
 
-        {/*<h2 className='fold__title fold__title--contact'>
+        <h2 className='fold__title fold__title--contact'>
           <Translate stringId="fieldReportFormContactsTitle" />
-        </h2>*/}
+        </h2>
 
         <React.Fragment>
           {

--- a/src/root/views/field-report-form/index.js
+++ b/src/root/views/field-report-form/index.js
@@ -876,12 +876,12 @@ class FieldReportForm extends React.Component {
     let responseTitle = status === 'EVT' ? strings.fieldReportFormResponseTitleEVT : strings.fieldReportFormResponseTitle;
 
     // We hide the entire Planned International Response section for COVID reports
-    const isCovidReport = this.state.data.isCovidReport;
-    if (isCovidReport === 'true') {
+    const isCovidReport = this.state.data.isCovidReport === 'true';
+    if (isCovidReport) {
       responseTitle = '';
     }
     return (
-      <Fold title={responseTitle} foldWrapperClass='fold--main fold--transparent'>
+      <Fold title={responseTitle} foldWrapperClass='fold--main fold--transparent' showHeader={!isCovidReport}>
         { this.state.data.isCovidReport === 'true' ? null : (
           <React.Fragment>
             <label className='form__label'>


### PR DESCRIPTION
Addresses issues raised in https://github.com/IFRCGo/go-frontend/issues/1325#issuecomment-668806740 :

 - Fixes heading in `Actions` section to say `Actions Taken` instead of `Contacts`
 - Fixes repetition of text in `Planned Response` subheading
 - Adds back `Contacts` as a heading in `Response` section.

@imohkay - handing over to you to look at the styling for the `Contacts` heading in the Response section of the Create Field Report section.