### PR TITLE
fix incorrect string mapping in field report frontend, refs #1508

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Release 4.3.12
+
+Hotfix release: Fix undefined string for Potentially Affected in Field Report frontend
+
 ### Release 4.3.11
 
 This release includes a lot of code changes to support future translations support, as well as significant changes toward implementing updated site designs.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "go-frontend",
-  "version": "4.3.11",
+  "version": "4.3.12",
   "private": true,
   "devDependencies": {
     "@babel/core": "7.9.0",

--- a/src/root/views/field-report.js
+++ b/src/root/views/field-report.js
@@ -371,7 +371,7 @@ class FieldReport extends React.Component {
       <React.Fragment>
         <dl className='dl-horizontal numeric-list'>
           <dt>
-            <Translate stringId='Potentially Affected (RC): '/>
+            <Translate stringId='fieldReportPotentiallyAffected'/>
           </dt>
           <dd>{n(get(data, 'num_potentially_affected'))}</dd>
           <dt>


### PR DESCRIPTION
Fixes a copy-paste error in the field report frontend, should solve #1508 . 

cc @nanometrenat 