### PR TITLE
Fix/1535 fr validation

### DIFF
--- a/src/root/views/field-report-form/cmp-planned-response-row.js
+++ b/src/root/views/field-report-form/cmp-planned-response-row.js
@@ -53,7 +53,7 @@ export default class PlanResponseRow extends React.Component {
               name={`${name}[status]`}
               id={`${name}-status`}
               classLabel='visually-hidden'
-              classWrapper='resp-status col col-8-sm'
+              classWrapper='resp-status col col-7-sm'
               options={options}
               selectedOption={values.status}
               onChange={this.onFieldChange.bind(this, 'status')}
@@ -66,11 +66,11 @@ export default class PlanResponseRow extends React.Component {
 
             <FormInput
               label={valueFieldLabel}
-              type='text'
+              type='number'
               name={`${name}[value]`}
               id={`${name}-value`}
               classLabel='label-secondary'
-              classWrapper='resp-value col col-3-sm'
+              classWrapper='resp-value col col-4-sm'
               value={values.value}
               onChange={this.onFieldChange.bind(this, 'value')} >
               <FormError

--- a/src/root/views/field-report-form/index.js
+++ b/src/root/views/field-report-form/index.js
@@ -911,9 +911,21 @@ class FieldReportForm extends React.Component {
     const { strings } = this.context;
     const fields = formData.getFieldsStep4(strings);
     const status = this.getStatus();
-    const plannedResponseRows = fields.plannedResponseRows.filter(row => {
-      return !!row.label[status];
-    });
+    const plannedResponseRows = fields.plannedResponseRows.filter(row => !!row.label[status]);
+    // The form sets all planned response statuses to "0" on submit including 
+    // the planned responses not listed. This hack resets ALL the planned responses so that validation
+    // can be successfully executed.
+    plannedResponseRows.map(row => this.state.data[row.key].status === "0" ? this.onFieldChange(row.key, {status: undefined, value: undefined}) : null);
+    if(this.state.data.rdrtrits.status === "0") {
+      this.onFieldChange('rdrtrits', {status: undefined, value: undefined});
+    } 
+    if(this.state.data.imminentDref.status === "0") {
+      this.onFieldChange('imminentDref', {status: undefined, value: undefined});
+    } 
+    if(this.state.data.forecastBasedAction.status === "0") {
+      this.onFieldChange('forecastBasedAction', {status: undefined, value: undefined});
+    } 
+
     let responseTitle = status === 'EVT' ? strings.fieldReportFormResponseTitleEVT : strings.fieldReportFormResponseTitle;
 
     // We hide the entire Planned International Response section for COVID reports


### PR DESCRIPTION
#1535
#1513
#1518

The root of the validation issue on the `planned response` is that the initial form values are `undefined` which is what is expected, but once the form is submitted, the field status (the radio button) is given a value of `"0"` which then registers as a "touched" entry. In addition to this, there are a number of fields that are apparently associated with the planned responses even though they aren't displayed (see https://github.com/IFRCGo/go-frontend/blob/b452e22864764286a830d7dc96b1adb9b9e2eee3/src/root/views/field-report-form/data-utils.js#L598)

I created a forced reset of these values on load of an existing form which allows the validation to behave normally. It's not an elegant solution by any means. I'd be happy to talk through a better solution @batpad if you have ideas. 

I also addressed the styling issues here as well and resolved some more form type issues

https://github.com/IFRCGo/go-frontend/pull/new/fix/1535-fr-validation