### PR TITLE
fix useEffect dependency issues, fix lint

### DIFF
--- a/src/root/views/Covid19ThreeWSankey/Filters.js
+++ b/src/root/views/Covid19ThreeWSankey/Filters.js
@@ -53,7 +53,7 @@ function NSActivitiesFilters (p) {
       .filter(d => d.type === 'receiving_ns')
       .map(d => ({ label: d.name, value: d.iso }))
       .sort(compareString),
-  ], [data]);
+  ], [data, countriesByIso]);
 
   return (
     <Faram

--- a/src/root/views/RegionalThreeW/map.js
+++ b/src/root/views/RegionalThreeW/map.js
@@ -98,7 +98,7 @@ function Map (props) {
       map.fitBounds(bbox);
       setMapLoaded(true);
     });
-  }, [map, setMapLoaded, regionId]);
+  }, [map, setMapLoaded, regionId, regions]);
 
   React.useEffect(() => {
     if (!map || !mapLoaded) {
@@ -148,7 +148,7 @@ function Map (props) {
         .setDOMContent(popoverContent.children[0])
         .addTo(map);
     });
-  }, [map, regionId, data, mapLoaded]);
+  }, [map, regionId, data, mapLoaded, countries]);
 
   const [supportingNSList, maxProjects] = React.useMemo(() => {
     const maxProjects = Math.max(...data.map(d => d.projects_count));

--- a/src/root/views/RegionalThreeW/ns-activities-filters.js
+++ b/src/root/views/RegionalThreeW/ns-activities-filters.js
@@ -48,7 +48,7 @@ function NSActivitiesFilters (p) {
       .filter(d => d.type === 'receiving_ns')
       .map(d => ({ label: d.name, value: d.iso }))
       .sort(compareString),
-  ], [data]);
+  ], [data, p.countriesByIso]);
 
   const { strings } = useContext(LanguageContext);
   return (


### PR DESCRIPTION
Fixes an issue where we needed to add all variables used in the function as dependency to the `useEffect` and `useMemo` methods, to get lint / build to pass.

@frozenhelium I'm going to go ahead and merge, but please could you take a look and let me know if this seems correct?

cc @geohacker 