### PR TITLE
fix stuck loading state on view field report page

### DIFF
--- a/src/root/views/field-report.js
+++ b/src/root/views/field-report.js
@@ -35,7 +35,7 @@ class FieldReport extends React.Component {
     }
 
     if (this.props.report.fetching && !nextProps.report.fetching) {
-      hideGlobalLoading();
+      hideGlobalLoading(0);
     }
   }
 


### PR DESCRIPTION
Fixes the case of global loading not disappearing on https://dsgoproxyapp.azurewebsites.net/reports/9637 when logged in.