### PR TITLE
use region label instead of enum name

### DIFF
--- a/src/root/components/header-region-button.js
+++ b/src/root/components/header-region-button.js
@@ -26,13 +26,13 @@ class HeaderRegionButton extends React.Component {
 
   render () {
     const { id, currentPath, regions, thisRegion } = this.props;
-    const title = thisRegion ? thisRegion.region_name : 'Regions';
+    const title = thisRegion ? thisRegion.label : 'Regions';
     const triggerClassName = this.decideTriggerClassName(currentPath);
     const regionLinks = Object.values(regions).map(r => {
       r = r[0];
       return {
         to: `/regions/${r.id}`,
-        text: r.region_name
+        text: r.label
       };
     });
     return (

--- a/src/root/components/per-forms/per-documents.js
+++ b/src/root/components/per-forms/per-documents.js
@@ -86,7 +86,7 @@ const PerDocuments = ({perOverviewForm, perForm, regionsById}) => {
         });
         countries.push(<div key={'countryDocument' + countryKey}><div className='heading-sub global-spacing-v'>{currentCountryName}</div>{perDocuments}<br /></div>);
       });
-      regions.push(<div key={'regionDocument' + regionKey}><span className='fold__title'>{regionsById[regionKey][0].region_name}</span>{countries}<br /></div>);
+      regions.push(<div key={'regionDocument' + regionKey}><span className='fold__title'>{regionsById[regionKey][0].label}</span>{countries}<br /></div>);
     });
     return regions;
   };

--- a/src/root/components/preparedness/factory/national-societies-engaged-per-graph-data-factory.js
+++ b/src/root/components/preparedness/factory/national-societies-engaged-per-graph-data-factory.js
@@ -5,7 +5,7 @@ export default class NationalSocietiesEngagedPerGraphDataFactory {
     if (!(typeof rawData.error !== 'undefined' && rawData.error !== null)) {
       rawData.data.results.forEach((region) => {
         const thisRegion = regionsById[region.id][0];
-        thisRegion['name'] = thisRegion['region_name'];
+        thisRegion['name'] = thisRegion['label'];
         preparedData.push(
           {
             region: thisRegion,

--- a/src/root/selectors/index.js
+++ b/src/root/selectors/index.js
@@ -89,7 +89,7 @@ export const regionByIdOrNameSelector = (state, name) => {
   if (state.regions && state.regions.data.results) {
     if (isNaN(name)) {
       const thisRegion = state.regions.data.results.find(region => {
-        return region.region_name.toLowerCase() === name.toLowerCase();
+        return region.label.toLowerCase() === name.toLowerCase();
       });
       return thisRegion;
     } else {

--- a/src/root/views/countries.js
+++ b/src/root/views/countries.js
@@ -595,7 +595,7 @@ class AdminArea extends SFPComponent {
     ];
     if (region) {
       crumbs.splice(1, 0, {
-        link: `/regions/${data.region}`, name: region.region_name
+        link: `/regions/${data.region}`, name: region.label
       });
     }
 
@@ -642,7 +642,7 @@ class AdminArea extends SFPComponent {
                 <Link to={`/regions/${data.region}`}
                   className='link link--with-icon flex-justify-center'
                 >
-                  <span className='link--with-icon-text'>{region.region_name}</span>
+                  <span className='link--with-icon-text'>{region.label}</span>
                   <span className='collecticon-chevron-right link--with-icon-inner'></span>
                 </Link>
               </div>

--- a/src/root/views/emergency.js
+++ b/src/root/views/emergency.js
@@ -512,7 +512,7 @@ class Emergency extends React.Component {
                         key={region}
                         className="link--table"
                       >
-                        { this.props.regionsById[region][0].region_name }
+                        { this.props.regionsById[region][0].label }
                       </Link>);
                     }) : nope }
                   </td>
@@ -819,7 +819,7 @@ class Emergency extends React.Component {
       regionId = country.region;
       if (regionId) {
         regionLink = `/regions/${regionId}`;
-        regionName = this.props.regionsById[regionId][0].region_name;
+        regionName = this.props.regionsById[regionId][0].label;
         crumbs.push({
           link: regionLink,
           name: regionName

--- a/src/root/views/region.js
+++ b/src/root/views/region.js
@@ -181,7 +181,7 @@ class AdminArea extends SFPComponent {
     });
 
     const mapBoundingBox = turfBbox(regions[data.id][0].bbox);
-    const regionName = thisRegion.region_name;
+    const regionName = thisRegion.label;
     const activeOperations = get(this.props.appealStats, 'data.results.length', false);
 
     const handleTabChange = index => {

--- a/src/root/views/table.js
+++ b/src/root/views/table.js
@@ -50,7 +50,7 @@ class Table extends React.Component {
     if (query.hasOwnProperty('region')) {
       const regionId = query.region;
       const thisRegion = this.props.regionsById[regionId][0];
-      titleArea = thisRegion.region_name;
+      titleArea = thisRegion.label;
       props.region = titleArea ? query.region : null;
     } else if (query.hasOwnProperty('country')) {
       titleArea = getCountryMeta(query.country, this.props.countries);
@@ -116,7 +116,7 @@ class Table extends React.Component {
         const region = this.props.regionsById[regionId][0];
         extraCrumbs.push({
           link: `/regions/${regionId}`,
-          name: region.region_name
+          name: region.label
         });
       }
       if (qs.hasOwnProperty('country')) {


### PR DESCRIPTION
Part of https://github.com/IFRCGo/go-frontend/issues/1534. Uses a label for each region from the API instead of the enum name.

cc @batpad 