### PR TITLE
Fix Countries dropdownlists (account, register pages)

### DIFF
--- a/src/root/utils/field-report-constants.js
+++ b/src/root/utils/field-report-constants.js
@@ -47,9 +47,10 @@ export const getVisibility = (strings) => [
 // This transforms a countries collection to be used
 // directly in a select dropdown
 export const countries = (countries) => {
+  const countriesSelectList = countries.map(country => ({ value: country.id, label: country.name }));
   return [
     {value: '-- Country --', label: ''},
-    ...countries,
+    ...countriesSelectList,
   ].sort((a, b) => a.label < b.label ? -1 : 1);
 };
 

--- a/src/root/utils/field-report-constants.js
+++ b/src/root/utils/field-report-constants.js
@@ -47,7 +47,13 @@ export const getVisibility = (strings) => [
 // This transforms a countries collection to be used
 // directly in a select dropdown
 export const countries = (countries) => {
-  const countriesSelectList = countries.map(country => ({ value: country.id, label: country.name }));
+  let countriesSelectList = [];
+  if (countries[0].hasOwnProperty('value') && countries[0].hasOwnProperty('label')) {
+    countriesSelectList = countries;
+  } else {
+    countriesSelectList = countries.map(country => ({ value: country.id, label: country.name }));
+  }
+
   return [
     {value: '-- Country --', label: ''},
     ...countriesSelectList,

--- a/src/root/views/account.js
+++ b/src/root/views/account.js
@@ -40,7 +40,6 @@ import PerAccountTab from '#components/per-forms/per-account-tab';
 import BreadCrumb from '../components/breadcrumb';
 import LanguageContext from '#root/languageContext';
 import Translate from '#components/Translate';
-import { countriesSelector } from '#selectors';
 
 import {
   FormCheckboxGroup,
@@ -635,6 +634,9 @@ class Account extends React.Component {
     Object.keys(this.props.event.event).forEach(event => {
       events.push(<input type='hidden' name='followedEvent' key={'followedEvent' + event} value={event} />);
     });
+    const countriesList = (this.props.countries && this.props.countries.fetched)
+      ? countries(this.props.countries.data.results)
+      : [];
     return (
       <form className='form' onSubmit={this.onNotificationSubmit}>
         <div className='fold-container'>
@@ -666,7 +668,7 @@ class Account extends React.Component {
                 name='countries'
                 value={this.state.notifications.countries}
                 onChange={this.onFieldChange.bind(this, 'notifications', 'countries')}
-                options={countries(this.props.allCountries)}
+                options={countriesList}
                 multi />
             </div>
             <FormCheckboxGroup
@@ -906,7 +908,7 @@ const selector = (state, ownProps) => ({
   eventDeletion: state.subscriptions.delSubscriptions,
   perOverviewForm: state.perForm.getPerOverviewForm,
   getPerMission: state.perForm.getPerMission,
-  allCountries: countriesSelector(state),
+  countries: state.countries
 });
 
 const dispatcher = (dispatch) => ({

--- a/src/root/views/account.js
+++ b/src/root/views/account.js
@@ -40,6 +40,7 @@ import PerAccountTab from '#components/per-forms/per-account-tab';
 import BreadCrumb from '../components/breadcrumb';
 import LanguageContext from '#root/languageContext';
 import Translate from '#components/Translate';
+import { countriesSelector } from '#selectors';
 
 import {
   FormCheckboxGroup,
@@ -634,9 +635,6 @@ class Account extends React.Component {
     Object.keys(this.props.event.event).forEach(event => {
       events.push(<input type='hidden' name='followedEvent' key={'followedEvent' + event} value={event} />);
     });
-    const countriesList = (this.props.countries && this.props.countries.fetched)
-      ? countries(this.props.countries.data.results)
-      : [];
     return (
       <form className='form' onSubmit={this.onNotificationSubmit}>
         <div className='fold-container'>
@@ -668,7 +666,7 @@ class Account extends React.Component {
                 name='countries'
                 value={this.state.notifications.countries}
                 onChange={this.onFieldChange.bind(this, 'notifications', 'countries')}
-                options={countriesList}
+                options={countries(this.props.allCountries)}
                 multi />
             </div>
             <FormCheckboxGroup
@@ -908,7 +906,7 @@ const selector = (state, ownProps) => ({
   eventDeletion: state.subscriptions.delSubscriptions,
   perOverviewForm: state.perForm.getPerOverviewForm,
   getPerMission: state.perForm.getPerMission,
-  countries: state.countries
+  allCountries: countriesSelector(state)
 });
 
 const dispatcher = (dispatch) => ({

--- a/src/root/views/register.js
+++ b/src/root/views/register.js
@@ -11,7 +11,7 @@ import { Helmet } from 'react-helmet';
 
 import { isValidEmail, isWhitelistedEmail, get } from '#utils/utils';
 import { countries, orgTypes } from '#utils/field-report-constants';
-import { registerUser, getDomainWhitelist, getCountries } from '#actions';
+import { registerUser, getDomainWhitelist } from '#actions';
 import { environment } from '#config';
 
 import { FormInput, FormError } from '#components/form-elements/';
@@ -68,7 +68,6 @@ class Register extends React.Component {
 
   componentDidMount () {
     this.props._getDomainWhitelist();
-    this.props._getCountries(null, true);
   }
 
   // eslint-disable-next-line camelcase
@@ -203,6 +202,9 @@ class Register extends React.Component {
 
   renderAdditionalInfo () {
     const { strings } = this.context;
+    const countriesList = (this.props.countries && this.props.countries.fetched)
+      ? countries(this.props.countries.data.results)
+      : [];
     return (
       <div className='form__hascol form__hascol--2'>
         <div className='form__group'>
@@ -213,7 +215,7 @@ class Register extends React.Component {
             name='country'
             value={this.state.data.country}
             onChange={this.onFieldChange.bind(this, 'country')}
-            options={countries} />
+            options={countriesList} />
           <FormError
             errors={this.state.errors}
             property='country'
@@ -528,7 +530,6 @@ const selector = (state) => ({
 const dispatcher = (dispatch) => ({
   _registerUser: (payload) => dispatch(registerUser(payload)),
   _getDomainWhitelist: () => dispatch(getDomainWhitelist()),
-  _getCountries: (...args) => dispatch(getCountries(...args))
 });
 
 Register.contextType = LanguageContext;


### PR DESCRIPTION
Ref.: https://github.com/IFRCGo/go-frontend/issues/1541

- Removed duplicate `getCountries()` call since the init has it now
- Refactored `countries` callback so it handles both a normal `countries` paramter or one changed with `countriesSelector`