### PR TITLE
Fix of hiding the global loading for Account page

### DIFF
--- a/src/root/views/account.js
+++ b/src/root/views/account.js
@@ -219,6 +219,7 @@ class Account extends React.Component {
 
   componentDidMount () {
     this.componentIsLoading = true;
+    showGlobalLoading();
     const { user, _getProfile, _getFieldReportsByUser, _getPerCountries, _getPerDocuments, _getPerDraftDocument } = this.props;
     _getProfile(user.username);
     _getFieldReportsByUser(user.id);
@@ -228,7 +229,6 @@ class Account extends React.Component {
     _getPerDraftDocument(draftQueryFilters);
     this.props._getPerOverviewForm();
     this.props._getPerMission();
-    showGlobalLoading();
     this.displayTabContent();
   }
 
@@ -252,7 +252,7 @@ class Account extends React.Component {
       }
     }
     if (this.props.profile.fetching && !nextProps.profile.fetching) {
-      hideGlobalLoading();
+      // hideGlobalLoading();
       if (nextProps.profile.error) {
         showAlert('danger', <p><strong><Translate stringId='accountError'/></strong><Translate stringId='accountCouldNotLoad'/></p>, true, 4500);
       } else {
@@ -261,7 +261,7 @@ class Account extends React.Component {
       }
     }
     if (this.props.profile.updating && !nextProps.profile.updating) {
-      hideGlobalLoading();
+      // hideGlobalLoading();
       if (nextProps.profile.updateError) {
         showAlert('danger', <p><strong><Translate stringId='accountError' /></strong> {nextProps.profile.updateError.detail}</p>, true, 4500);
       } else {
@@ -273,6 +273,10 @@ class Account extends React.Component {
     if (this.props.perForm.deletePerDraft.receivedAt !== nextProps.perForm.deletePerDraft.receivedAt) {
       const draftQueryFilters = { user: this.props.user.id };
       this.props._getPerDraftDocument(draftQueryFilters);
+    }
+
+    if (nextProps.profile.fetched === true) {
+      hideGlobalLoading();
     }
   }
 

--- a/src/root/views/account.js
+++ b/src/root/views/account.js
@@ -252,7 +252,6 @@ class Account extends React.Component {
       }
     }
     if (this.props.profile.fetching && !nextProps.profile.fetching) {
-      // hideGlobalLoading();
       if (nextProps.profile.error) {
         showAlert('danger', <p><strong><Translate stringId='accountError'/></strong><Translate stringId='accountCouldNotLoad'/></p>, true, 4500);
       } else {
@@ -261,7 +260,6 @@ class Account extends React.Component {
       }
     }
     if (this.props.profile.updating && !nextProps.profile.updating) {
-      // hideGlobalLoading();
       if (nextProps.profile.updateError) {
         showAlert('danger', <p><strong><Translate stringId='accountError' /></strong> {nextProps.profile.updateError.detail}</p>, true, 4500);
       } else {


### PR DESCRIPTION
Ref.: https://github.com/IFRCGo/go-frontend/issues/1491#issuecomment-684764151

This should fix the loading issue, at least I couldn't reproduce the bug after this change. Needs testing on staging as well for sure.