### PR TITLE
Fix homepage key-figures (null error for centroid)

### DIFF
--- a/src/root/utils/utils.js
+++ b/src/root/utils/utils.js
@@ -70,7 +70,7 @@ export function aggregateCountryAppeals (appeals, countries) {
         }),
         geometry: {
           type: 'Point',
-          coordinates: getCountryMeta(countryAppeals[0].country.id, countries).centroid.coordinates || [0, 0]
+          coordinates: getCountryMeta(countryAppeals[0].country.id, countries).centroid?.coordinates || [0, 0]
         }
       };
     })


### PR DESCRIPTION
Ref.: https://github.com/IFRCGo/go-frontend/issues/1550

## Notes
- `console.log()`-ed error: `TypeError: Cannot read property 'coordinates' of null (key-figures-header.js:74)`

Also keep in mind https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining#Browser_compatibility
I've ran into issues with this with the Tableau Web Data Connector, because the application uses some older version of the Chromium engine.

@geohacker Feel free to take over if you think this wouldn't fix the whole issue.