### PR TITLE
Fix centroid nullchecks

### DIFF
--- a/src/root/reducers/eru-owners.js
+++ b/src/root/reducers/eru-owners.js
@@ -104,7 +104,7 @@ function createStoreFromRaw (raw, state) {
         properties,
         geometry: {
           type: 'Point',
-          coordinates: countrySelector(state, id).centroid.coordinates || [0, 0]
+          coordinates: countrySelector(state, id).centroid?.coordinates || [0, 0]
         }
       };
     })

--- a/src/root/views/RegionalThreeW/map.js
+++ b/src/root/views/RegionalThreeW/map.js
@@ -23,7 +23,7 @@ function getGeojsonFromMovementActivities (movementActivities = emptyList, count
         type: 'Feature',
         geometry: {
           type: 'Point',
-          coordinates: getCountryMeta(d.id, countries).centroid.coordinates || [0, 0],
+          coordinates: getCountryMeta(d.id, countries).centroid?.coordinates || [0, 0],
         },
         properties: {
           ...d,

--- a/src/root/views/preparedness.js
+++ b/src/root/views/preparedness.js
@@ -61,7 +61,7 @@ class Preparedness extends React.Component {
         if (perForm.country) {
           let countryMeta = getCountryMeta(perForm.country.id, this.props.countries);
           perForm.country.iso = countryMeta.iso;
-          let countryCentroid = countryMeta.centroid.coordinates || [0, 0];
+          let countryCentroid = countryMeta.centroid?.coordinates || [0, 0];
           perForm.country.centroid = countryCentroid;
 
           geoJson.features.push({


### PR DESCRIPTION
Followup of: https://github.com/IFRCGo/go-frontend/pull/1551

Fixes the remaning possible null errors of the `centroid` object.