### PR TITLE
refs #1499, remove extraneous empty country at top of select

### DIFF
--- a/src/root/utils/field-report-constants.js
+++ b/src/root/utils/field-report-constants.js
@@ -65,7 +65,6 @@ export const countries = (countries, independent=false) => {
   }
 
   return [
-    {value: '-- Country --', label: ''},
     ...countriesSelectList,
   ].sort((a, b) => a.label < b.label ? -1 : 1);
 };


### PR DESCRIPTION
Refs #1499 - remove empty country at the top of the country dropdown list on the field report form

cc @geohacker 