### PR TITLE
Multilingual map labels

### DIFF
--- a/src/root/components/connected/emergencies-dash.js
+++ b/src/root/components/connected/emergencies-dash.js
@@ -10,6 +10,7 @@ import EmergenciesMap from '#components/map/emergencies-map';
 import Progress from '#components/progress';
 import BlockLoading from '#components/block-loading';
 import Translate from '#components/Translate';
+import { countriesGeojsonSelector } from '../../selectors';
 
 class EmergenciesDash extends React.Component {
   renderEmergencies () {
@@ -158,7 +159,10 @@ class EmergenciesDash extends React.Component {
               </div>
             </div>
           </div>
-          <EmergenciesMap lastMonth={lastMonth} />
+          <EmergenciesMap
+            lastMonth={lastMonth}
+            countriesGeojson={this.props.countriesGeojson}
+          />
         </section>
       </div>
     );
@@ -177,7 +181,8 @@ if (environment !== 'production') {
 
 const selector = (state) => ({
   lastMonth: state.emergencies.lastMonth,
-  aggregate: state.emergencies.aggregate
+  aggregate: state.emergencies.aggregate,
+  countriesGeojson: countriesGeojsonSelector(state)
 });
 
 export default connect(selector)(EmergenciesDash);

--- a/src/root/components/connected/presentation-dash.js
+++ b/src/root/components/connected/presentation-dash.js
@@ -24,7 +24,7 @@ import TimelineCharts from '#components/timeline-charts';
 import AppealsTable from '#components/connected/appeals-table';
 import MainMap from '#components/map/main-map';
 import LanguageContext from '#root/languageContext';
-
+import { countriesGeojsonSelector } from '#selectors';
 class PresentationDash extends React.Component {
   constructor (props) {
     super(props);
@@ -92,6 +92,7 @@ class PresentationDash extends React.Component {
                   noRenderEmergencies={true}
                   fullscreen={this.state.fullscreen}
                   toggleFullscreen={this.toggleFullscreen}
+                  countriesGeojson={this.props.countriesGeojson}
                 />
               )
               : null
@@ -131,7 +132,8 @@ if (environment !== 'production') {
 const selector = (state, props) => ({
   appeals: props.statePath ? get(state, props.statePath) : state.appeals,
   appealsList: state.overallStats.appealsList,
-  aggregate: state.overallStats.aggregate
+  aggregate: state.overallStats.aggregate,
+  countriesGeojson: countriesGeojsonSelector(state)
 });
 
 const dispatcher = (dispatch) => ({

--- a/src/root/components/map/common/map-component.js
+++ b/src/root/components/map/common/map-component.js
@@ -34,16 +34,16 @@ export default class MapComponent extends React.Component {
         type: 'geojson',
         data: this.props.countriesGeojson
       });
+      // hide stock labels
+      this.theMap.setLayoutProperty('icrc_admin0_labels', 'visibility', 'none');
+
+      // add custom language labels
+      this.theMap.addLayer(countryLabels);
     }
 
     get(this.props, 'layers', []).forEach(layer => this.theMap.addLayer(layer));
     get(this.props, 'filters', []).forEach(this.safeSetFilter);
 
-    // hide stock labels
-    this.theMap.setLayoutProperty('icrc_admin0_labels', 'visibility', 'none');
-
-    // add custom language labels
-    this.theMap.addLayer(countryLabels);
   }
 
   safeSetFilter (filter) {

--- a/src/root/components/map/common/map-component.js
+++ b/src/root/components/map/common/map-component.js
@@ -36,6 +36,7 @@ export default class MapComponent extends React.Component {
       });
       // hide stock labels
       this.theMap.setLayoutProperty('icrc_admin0_labels', 'visibility', 'none');
+      this.theMap.setLayoutProperty('additional-geography-labels', 'visibility', 'none');
 
       // add custom language labels
       this.theMap.addLayer(countryLabels);

--- a/src/root/components/map/common/map-component.js
+++ b/src/root/components/map/common/map-component.js
@@ -36,7 +36,6 @@ export default class MapComponent extends React.Component {
       });
       // hide stock labels
       this.theMap.setLayoutProperty('icrc_admin0_labels', 'visibility', 'none');
-      this.theMap.setLayoutProperty('additional-geography-labels', 'visibility', 'none');
 
       // add custom language labels
       this.theMap.addLayer(countryLabels);

--- a/src/root/components/map/common/map-component.js
+++ b/src/root/components/map/common/map-component.js
@@ -9,6 +9,7 @@ import exportMap from '#utils/export-map';
 import DownloadButton from './download-button';
 import MapHeader from './map-header';
 import Translate from '#components/Translate';
+import { countryLabels } from '#utils/country-labels';
 
 export default class MapComponent extends React.Component {
   constructor (props) {
@@ -27,8 +28,22 @@ export default class MapComponent extends React.Component {
         data: this.props.geoJSON
       });
     }
+
+    if (this.props.countriesGeojson) {
+      this.theMap.addSource('countryCentroids', {
+        type: 'geojson',
+        data: this.props.countriesGeojson
+      });
+    }
+
     get(this.props, 'layers', []).forEach(layer => this.theMap.addLayer(layer));
     get(this.props, 'filters', []).forEach(this.safeSetFilter);
+
+    // hide stock labels
+    this.theMap.setLayoutProperty('icrc_admin0_labels', 'visibility', 'none');
+
+    // add custom language labels
+    this.theMap.addLayer(countryLabels);
   }
 
   safeSetFilter (filter) {
@@ -122,6 +137,7 @@ if (environment !== 'production') {
     className: T.string,
     noExport: T.bool,
     downloadButton: T.bool,
-    downloadedHeaderTitle: T.string
+    downloadedHeaderTitle: T.string,
+    countriesGeojson: T.object
   };
 }

--- a/src/root/components/map/deployments-map.js
+++ b/src/root/components/map/deployments-map.js
@@ -272,8 +272,8 @@ export default class DeploymentsMap extends React.Component {
               downloadedHeaderTitle={strings.deploymentsMapDownloadTitle}
               layers={this.state.layers}
               filters={this.state.filters}
-              geoJSON={this.props.data}>
-
+              geoJSON={this.props.data}
+              countriesGeojson={this.props.countriesGeojson}>
               <figcaption className='map-vis__legend map-vis__legend--bottom-right legend'>
                 <div className='deployments-key'>
                   <div>
@@ -341,7 +341,8 @@ export default class DeploymentsMap extends React.Component {
 DeploymentsMap.contextType = LanguageContext;
 if (environment !== 'production') {
   DeploymentsMap.propTypes = {
-    data: T.object
+    data: T.object,
+    countriesGeojson: T.object
   };
 }
 

--- a/src/root/components/map/emergencies-map.js
+++ b/src/root/components/map/emergencies-map.js
@@ -151,7 +151,8 @@ class EmergenciesMap extends React.Component {
                 downloadedHeaderTitle={strings.emergenciesMapDownloadTitle}
                 layers={this.state.layers}
                 filters={this.state.filters}
-                geoJSON={data.geoJSON}>
+                geoJSON={data.geoJSON}
+                countriesGeojson={this.props.countriesGeojson}>
                 <figcaption className='map-vis__legend map-vis__legend--bottom-right legend'>
                   <div className='legend__group'>
                     <form className='form'>
@@ -211,7 +212,8 @@ class EmergenciesMap extends React.Component {
 if (environment !== 'production') {
   EmergenciesMap.propTypes = {
     lastMonth: T.object,
-    history: T.object
+    history: T.object,
+    countriesGeojson: T.object
   };
 }
 

--- a/src/root/components/map/main-map.js
+++ b/src/root/components/map/main-map.js
@@ -306,6 +306,7 @@ class MainMap extends React.Component {
             configureMap={this.configureMap}
             layers={layers}
             geoJSON={geoJSON}
+            countriesGeojson={this.props.countriesGeojson}
             downloadButton={true}
             downloadedHeaderTitle={strings.mainMapDownloadHeaderTitle}>
 
@@ -351,7 +352,8 @@ if (environment !== 'production') {
     noExport: T.bool,
     layers: T.array,
     toggleFullscreen: T.func,
-    fullscreen: T.bool
+    fullscreen: T.bool,
+    countriesGeojson: T.object
   };
 }
 

--- a/src/root/selectors/index.js
+++ b/src/root/selectors/index.js
@@ -77,6 +77,32 @@ export const countriesByIso = (state) => {
   }
 };
 
+export const countriesGeojsonSelector = (state) => {
+  const featureCollection = {
+    'type': 'FeatureCollection',
+    'features': []
+  };
+  if (state.allCountries && state.allCountries.data.results) {
+
+    state.allCountries.data.results.forEach(country => {
+      if (country.centroid && country.independent) {
+        const f = {
+          'type': 'Feature',
+          'geometry': country.centroid,
+          'properties': {
+            'name': country.name,
+            'iso': country.iso,
+            'iso3': country.iso3,
+            'society_name': country.society_name
+          }
+        };
+        featureCollection.features.push(f);
+      }
+    });
+  }
+  return featureCollection;
+};
+
 export const regionsByIdSelector = (state) => {
   if (state.allRegions && state.allRegions.data.results) {
     return _groupBy(state.allRegions.data.results, 'id');

--- a/src/root/selectors/index.js
+++ b/src/root/selectors/index.js
@@ -4,6 +4,7 @@ import _find from 'lodash.find';
 
 import { defaultInitialState } from '#utils/reducer-utils';
 import { compareString } from '#utils/utils';
+import { palestineLabel } from '#utils/special-map-labels';
 
 const initialState = { ...defaultInitialState };
 
@@ -83,14 +84,14 @@ export const countriesGeojsonSelector = (state) => {
     'features': []
   };
   if (state.allCountries && state.allCountries.data.results) {
-
+    const currentLang = currentLanguageSelector(state);
     state.allCountries.data.results.forEach(country => {
       if (country.centroid && (country.independent || country.independent === null)) {
         const f = {
           'type': 'Feature',
           'geometry': country.centroid,
           'properties': {
-            'name': country.name,
+            'name': country.iso === 'ps' ? palestineLabel(currentLang) : country.name,
             'iso': country.iso,
             'iso3': country.iso3,
             'society_name': country.society_name
@@ -99,6 +100,7 @@ export const countriesGeojsonSelector = (state) => {
         featureCollection.features.push(f);
       }
     });
+
     return featureCollection;
   } else {
     return null;

--- a/src/root/selectors/index.js
+++ b/src/root/selectors/index.js
@@ -99,8 +99,10 @@ export const countriesGeojsonSelector = (state) => {
         featureCollection.features.push(f);
       }
     });
+    return featureCollection;
+  } else {
+    return null;
   }
-  return featureCollection;
 };
 
 export const regionsByIdSelector = (state) => {

--- a/src/root/selectors/index.js
+++ b/src/root/selectors/index.js
@@ -85,7 +85,7 @@ export const countriesGeojsonSelector = (state) => {
   if (state.allCountries && state.allCountries.data.results) {
 
     state.allCountries.data.results.forEach(country => {
-      if (country.centroid && country.independent) {
+      if (country.centroid && (country.independent || country.independent === null)) {
         const f = {
           'type': 'Feature',
           'geometry': country.centroid,

--- a/src/root/utils/country-labels.js
+++ b/src/root/utils/country-labels.js
@@ -1,0 +1,25 @@
+export const countryLabels = {
+  'id': 'countryLabels',
+  'source': 'countryCentroids',
+  'type': 'symbol',
+  layout: {
+    'text-field': ['get', 'name'],
+    'text-font': ['Arial Unicode MS Regular'],
+    'text-letter-spacing': 0.15,
+    'text-line-height': 1.2,
+    'text-max-width': 8,
+    'text-justify': 'center',
+    'text-anchor': 'top',
+    'text-padding': 2,
+    'text-size': [
+      'interpolate', ['linear', 1], ['zoom'],
+      0, 6,
+      6, 16
+    ]
+  },
+  paint: {
+   'text-color': '#2d4662',
+   'text-halo-color': '#2d4662',
+   'text-halo-width': 0.2
+  }
+};

--- a/src/root/utils/special-map-labels.js
+++ b/src/root/utils/special-map-labels.js
@@ -1,0 +1,13 @@
+// This util exports places for labeling several special entities.
+
+export function palestineLabel (lang) {
+  const name = {
+    'en': 'State of Palestine',
+    'fr': 'État de Palestine',
+    'es': 'Estado de Palestina',
+    'ar': 'دولة فلسطين'
+  };
+
+  return name[lang];
+}
+

--- a/src/root/views/CountryProfile/Map.js
+++ b/src/root/views/CountryProfile/Map.js
@@ -3,6 +3,7 @@ import React from 'react';
 import newMap from '#utils/get-new-map';
 import { getCountryMeta } from '../../utils/get-country-meta';
 import turfBbox from '@turf/bbox';
+import { countryLabels } from '#utils/country-labels';
 
 export default class ThreeWMap extends React.PureComponent {
   constructor (props) {
@@ -50,7 +51,21 @@ export default class ThreeWMap extends React.PureComponent {
       countryId,
       districtList,
       countries,
+      countriesGeojson
     } = this.props;
+
+    if (countriesGeojson) {
+      this.map.addSource('countryCentroids', {
+        type: 'geojson',
+        data: countriesGeojson
+      });
+      // hide stock labels
+      this.map.setLayoutProperty('icrc_admin0_labels', 'visibility', 'none');
+    }
+
+
+    // add custom language labels
+    this.map.addLayer(countryLabels);
 
     this.fillMap(countryId, districtList, countries);
   }

--- a/src/root/views/CountryProfile/PopulationMap.js
+++ b/src/root/views/CountryProfile/PopulationMap.js
@@ -14,6 +14,7 @@ class PopulationMap extends React.PureComponent {
       countryId,
       data,
       countries,
+      countriesGeojson
     } = this.props;
 
     return (
@@ -28,6 +29,7 @@ class PopulationMap extends React.PureComponent {
           countryId={countryId}
           districtList={data.districts}
           countries={countries}
+          countriesGeojson={countriesGeojson}
         />
       </Container>
     );

--- a/src/root/views/CountryProfile/index.js
+++ b/src/root/views/CountryProfile/index.js
@@ -19,7 +19,7 @@ import KeyDocuments from './KeyDocuments';
 import ExternalSources from './ExternalSources';
 
 import styles from './styles.module.scss';
-import { countriesSelector } from '../../selectors';
+import { countriesSelector, countriesGeojsonSelector } from '../../selectors';
 import { getCountryMeta } from '../../utils/get-country-meta';
 
 function Section(p) {
@@ -105,6 +105,7 @@ class CountryOverview extends React.PureComponent {
             className={styles.populationMap}
             data={data.wb_population}
             countries={this.props.countries}
+            countriesGeojson={this.props.countriesGeojson}
           />
           <ClimateChart
             className={styles.climateChart}
@@ -148,6 +149,7 @@ class CountryOverview extends React.PureComponent {
 const mapStateToProps = (state) => ({
   countryOverview: countryOverviewSelector(state),
   countries: countriesSelector(state),
+  countriesGeojson: countriesGeojsonSelector(state)
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/root/views/RegionalThreeW/index.js
+++ b/src/root/views/RegionalThreeW/index.js
@@ -39,7 +39,7 @@ import MovementActivitiesFilters from './movement-activities-filters';
 import NSActivitiesFilters from './ns-activities-filters';
 import ExportButton from './export-button';
 import Map from './map';
-import { countriesSelector, regionsByIdSelector } from '../../selectors';
+import { countriesSelector, regionsByIdSelector, countriesGeojsonSelector } from '../../selectors';
 
 const emptyList = [];
 
@@ -126,6 +126,7 @@ function RegionalThreeW (p) {
     projectFormResponse,
     countries,
     regions,
+    countriesGeojson
   } = p;
 
   const [showProjectForm, setShowProjectForm] = React.useState(false);
@@ -282,6 +283,7 @@ function RegionalThreeW (p) {
             data={movementActivityList}
             countries={countries}
             regions={regions}
+            countriesGeojson={countriesGeojson}
           />
           <div className='countries-threew-tables'>
             { movementActivityList.map(c => (
@@ -350,6 +352,7 @@ const mapStateToProps = (state) => ({
   projectFormResponse: state.projectForm,
   countries: countriesSelector(state),
   regions: regionsByIdSelector(state),
+  countriesGeojson: countriesGeojsonSelector(state)
 });
 
 const mapDispatchToProps = (dispatch) => ({

--- a/src/root/views/RegionalThreeW/map.js
+++ b/src/root/views/RegionalThreeW/map.js
@@ -11,6 +11,7 @@ import ActivityDetails from './activity-details';
 import Translate from '#components/Translate';
 import { getCountryMeta } from '../../utils/get-country-meta';
 import turfBbox from '@turf/bbox';
+import { countryLabels } from '#utils/country-labels';
 
 const emptyList = [];
 
@@ -77,6 +78,7 @@ function Map (props) {
     data,
     countries,
     regions,
+    countriesGeojson
   } = props;
 
   const ref = React.useRef();
@@ -112,9 +114,25 @@ function Map (props) {
         map.removeLayer('movement-activity-circles');
       }
       map.removeSource('movement-activity-markers');
+
+      if (map.getLayer('countryLabels')) {
+        map.removeLayer('countryLabels');
+      }
+      map.removeSource('countryCentroids');
     } catch (err) {
       // pass
     }
+
+    // add custom labels
+    map.setLayoutProperty('icrc_admin0_labels', 'visibility', 'none');
+    if (countriesGeojson) {
+      map.addSource('countryCentroids', {
+        type: 'geojson',
+        data: countriesGeojson
+      });
+    }
+
+    map.addLayer(countryLabels);
 
     map.addSource('movement-activity-markers', geojson);
     map.addLayer({

--- a/src/root/views/RegionalThreeW/map.js
+++ b/src/root/views/RegionalThreeW/map.js
@@ -132,6 +132,7 @@ function Map (props) {
 
       // hide stock labels
       map.setLayoutProperty('icrc_admin0_labels', 'visibility', 'none');
+      map.setLayoutProperty('additional-geography-labels', 'visibility', 'none');
 
       map.addLayer(countryLabels);
     }

--- a/src/root/views/RegionalThreeW/map.js
+++ b/src/root/views/RegionalThreeW/map.js
@@ -124,15 +124,17 @@ function Map (props) {
     }
 
     // add custom labels
-    map.setLayoutProperty('icrc_admin0_labels', 'visibility', 'none');
     if (countriesGeojson) {
       map.addSource('countryCentroids', {
         type: 'geojson',
         data: countriesGeojson
       });
-    }
 
-    map.addLayer(countryLabels);
+      // hide stock labels
+      map.setLayoutProperty('icrc_admin0_labels', 'visibility', 'none');
+
+      map.addLayer(countryLabels);
+    }
 
     map.addSource('movement-activity-markers', geojson);
     map.addLayer({

--- a/src/root/views/RegionalThreeW/map.js
+++ b/src/root/views/RegionalThreeW/map.js
@@ -132,7 +132,6 @@ function Map (props) {
 
       // hide stock labels
       map.setLayoutProperty('icrc_admin0_labels', 'visibility', 'none');
-      map.setLayoutProperty('additional-geography-labels', 'visibility', 'none');
 
       map.addLayer(countryLabels);
     }

--- a/src/root/views/ThreeW/map.js
+++ b/src/root/views/ThreeW/map.js
@@ -173,6 +173,7 @@ class ThreeWMap extends React.PureComponent {
 
       // hide stock labels
       this.map.setLayoutProperty('icrc_admin0_labels', 'visibility', 'none');
+      this.map.setLayoutProperty('additional-geography-labels', 'visibility', 'none');
 
       this.map.addLayer(countryLabels);
     }

--- a/src/root/views/ThreeW/map.js
+++ b/src/root/views/ThreeW/map.js
@@ -173,7 +173,6 @@ class ThreeWMap extends React.PureComponent {
 
       // hide stock labels
       this.map.setLayoutProperty('icrc_admin0_labels', 'visibility', 'none');
-      this.map.setLayoutProperty('additional-geography-labels', 'visibility', 'none');
 
       this.map.addLayer(countryLabels);
     }

--- a/src/root/views/ThreeW/map.js
+++ b/src/root/views/ThreeW/map.js
@@ -19,6 +19,8 @@ import LanguageContext from '#root/languageContext';
 import { getCountryMeta } from '#utils/get-country-meta';
 import { countriesSelector } from '#selectors';
 import turfBbox from '@turf/bbox';
+import { countriesGeojsonSelector } from '../../selectors';
+import { countryLabels } from '../../utils/country-labels';
 
 const emptyList = [];
 const emptyObject = {};
@@ -162,6 +164,16 @@ class ThreeWMap extends React.PureComponent {
       districtsResponse,
     } = this.props;
 
+    // add custom labels
+    this.map.setLayoutProperty('icrc_admin0_labels', 'visibility', 'none');
+    if (this.props.countriesGeojson) {
+      this.map.addSource('countryCentroids', {
+        type: 'geojson',
+        data: this.props.countriesGeojson
+      });
+    }
+
+    this.map.addLayer(countryLabels);
     this.fillMap(countryId, projectList, districtsResponse);
   }
 
@@ -333,7 +345,8 @@ ThreeWMap.contextType = LanguageContext;
 
 const selector = (state, ownProps) => ({
   districtsResponse: state.districts,
-  countries: countriesSelector(state)
+  countries: countriesSelector(state),
+  countriesGeojson: countriesGeojsonSelector(state)
 });
 
 const dispatcher = dispatch => ({

--- a/src/root/views/ThreeW/map.js
+++ b/src/root/views/ThreeW/map.js
@@ -165,15 +165,18 @@ class ThreeWMap extends React.PureComponent {
     } = this.props;
 
     // add custom labels
-    this.map.setLayoutProperty('icrc_admin0_labels', 'visibility', 'none');
     if (this.props.countriesGeojson) {
       this.map.addSource('countryCentroids', {
         type: 'geojson',
         data: this.props.countriesGeojson
       });
+
+      // hide stock labels
+      this.map.setLayoutProperty('icrc_admin0_labels', 'visibility', 'none');
+
+      this.map.addLayer(countryLabels);
     }
 
-    this.map.addLayer(countryLabels);
     this.fillMap(countryId, projectList, districtsResponse);
   }
 

--- a/src/root/views/deployments.js
+++ b/src/root/views/deployments.js
@@ -34,6 +34,7 @@ import Readiness from '#components/deployments/readiness';
 import BreadCrumb from '#components/breadcrumb';
 import LanguageContext from '#root/languageContext';
 import Translate from '#components/Translate';
+import { countriesGeojsonSelector } from '../selectors';
 
 class Deployments extends SFPComponent {
   // Methods form SFPComponent:
@@ -239,7 +240,10 @@ class Deployments extends SFPComponent {
             </div>
           </header>
           <div className='container-lg'>
-            <DeploymentsMap data={this.props.locations} />
+            <DeploymentsMap
+              data={this.props.locations}
+              countriesGeojson={this.props.countriesGeojson}
+            />
           </div>
           <div className='inpage__body container-lg'>
             <div className='inner'>
@@ -294,14 +298,16 @@ if (environment !== 'production') {
     eruOwners: T.object,
     eru: T.object,
     activePersonnel: T.object,
-    locations: T.object
+    locations: T.object,
+    countriesGeojson: T.object
   };
 }
 
 const selector = (state) => ({
   eruOwners: state.eruOwners,
   activePersonnel: state.deployments.activePersonnel,
-  locations: state.deployments.locations
+  locations: state.deployments.locations,
+  countriesGeojson: countriesGeojsonSelector(state)
 });
 
 const dispatcher = (dispatch) => ({

--- a/src/root/views/region.js
+++ b/src/root/views/region.js
@@ -50,7 +50,7 @@ import MainMap from '#components/map/main-map';
 import LanguageContext from '#root/languageContext';
 import { resolveToString } from '#utils/lang';
 
-import { countriesSelector, countriesByRegionSelector, regionsByIdSelector, regionByIdOrNameSelector } from '../selectors';
+import { countriesSelector, countriesByRegionSelector, regionsByIdSelector, regionByIdOrNameSelector, countriesGeojsonSelector } from '../selectors';
 import turfBbox from '@turf/bbox';
 
 class AdminArea extends SFPComponent {
@@ -258,6 +258,7 @@ class AdminArea extends SFPComponent {
                             fullscreen={this.state.fullscreen}
                             toggleFullscreen={this.toggleFullscreen}
                             mapBoundingBox={mapBoundingBox}
+                            countriesGeojson={this.props.countriesGeojson}
                             // layers={this.state.maskLayer}
                           />
                           <AppealsTable
@@ -381,7 +382,8 @@ const selector = (state, ownProps) => ({
   appealsListStats: state.overallStats.appealsListStats,
   countriesByRegion: countriesByRegionSelector(state),
   regions: regionsByIdSelector(state),
-  thisRegion: regionByIdOrNameSelector(state, ownProps.match.params.id)
+  thisRegion: regionByIdOrNameSelector(state, ownProps.match.params.id),
+  countriesGeojson: countriesGeojsonSelector(state)
 });
 
 const dispatcher = (dispatch) => ({


### PR DESCRIPTION
This PR hides the default text layer on Mapbox maps and introduces a custom layer to show country labels based on the users current language selection.