### PR TITLE
Remove border-bottom from Lang. Select style

### DIFF
--- a/src/root/components/LanguageSelect/styles.module.scss
+++ b/src/root/components/LanguageSelect/styles.module.scss
@@ -18,7 +18,6 @@
   display: flex;
   align-items: center;
   padding: 3px 6px;
-  // border-bottom: 2px solid transparent;
 
   &:focus {
     outline: 0;

--- a/src/root/components/LanguageSelect/styles.module.scss
+++ b/src/root/components/LanguageSelect/styles.module.scss
@@ -18,7 +18,7 @@
   display: flex;
   align-items: center;
   padding: 3px 6px;
-  border-bottom: 2px solid transparent;
+  // border-bottom: 2px solid transparent;
 
   &:focus {
     outline: 0;


### PR DESCRIPTION
Aligns the Language dropdown with the other elements of that line.