### PR TITLE
Fix/empty countryname

### DIFF
--- a/src/root/components/connected/appeals-table.js
+++ b/src/root/components/connected/appeals-table.js
@@ -224,7 +224,6 @@ class AppealsTable extends SFPComponent {
       const rows = data.results.map(o => {
         const fundedPercent = (parseInt(o.amount_funded) / parseInt(o.amount_requested)) * 100;
         const fundedPercentRounded = Math.round(fundedPercent * 100) / 100;
-        console.log(o);
         const name = o.event ? (<Link to={`/emergencies/${o.event}`} className='link--table' title={strings.appealsTableViewEmergency}>
             {o.name}
           </Link>): o.name;

--- a/src/root/components/connected/appeals-table.js
+++ b/src/root/components/connected/appeals-table.js
@@ -130,6 +130,7 @@ class AppealsTable extends SFPComponent {
       error,
       data
     } = this.props.appeals;
+    console.log(this.props);
 
     const { strings } = this.context;
     const title = this.props.title || strings.appealsTableTitle;
@@ -224,6 +225,7 @@ class AppealsTable extends SFPComponent {
       const rows = data.results.map(o => {
         const fundedPercent = (parseInt(o.amount_funded) / parseInt(o.amount_requested)) * 100;
         const fundedPercentRounded = Math.round(fundedPercent * 100) / 100;
+        console.log(o);
         const name = o.event ? (<Link to={`/emergencies/${o.event}`} className='link--table' title={strings.appealsTableViewEmergency}>
             {o.name}
           </Link>): o.name;
@@ -312,7 +314,7 @@ if (environment !== 'production') {
 
     limit: T.number,
     country: T.number,
-    region: T.string,
+    region: T.number,
     atype: T.string,
     record: T.string,
 

--- a/src/root/components/connected/appeals-table.js
+++ b/src/root/components/connected/appeals-table.js
@@ -130,7 +130,6 @@ class AppealsTable extends SFPComponent {
       error,
       data
     } = this.props.appeals;
-    console.log(this.props);
 
     const { strings } = this.context;
     const title = this.props.title || strings.appealsTableTitle;

--- a/src/root/components/connected/emergencies-table.js
+++ b/src/root/components/connected/emergencies-table.js
@@ -244,7 +244,7 @@ if (environment !== 'production') {
 
     limit: T.number,
     country: T.string,
-    region: T.string,
+    region: T.number,
 
     noPaginate: T.bool,
     showExport: T.bool,

--- a/src/root/components/country-list.js
+++ b/src/root/components/country-list.js
@@ -29,7 +29,11 @@ const CountryList = props => {
    * @type {object} with a key of the letter and value of an array with countries
    */
   const alphabetizedList = countries.reduce((prev, country) => {
-    const letter = country.name ? country.name[0] : '';
+    if (!country.name) {
+      // it is possible a country name is null, in which case don't add to list.
+      return prev;
+    }
+    const letter = country.name[0];
     // Only adds countries with active operations
     const activeCountries = country.numOperations ? (
       {[letter]: [...(prev[letter] || []), country]}

--- a/src/root/components/country-list.js
+++ b/src/root/components/country-list.js
@@ -29,7 +29,7 @@ const CountryList = props => {
    * @type {object} with a key of the letter and value of an array with countries
    */
   const alphabetizedList = countries.reduce((prev, country) => {
-    const letter = country.name[0];
+    const letter = country.name ? country.name[0] : '';
     // Only adds countries with active operations
     const activeCountries = country.numOperations ? (
       {[letter]: [...(prev[letter] || []), country]}
@@ -70,7 +70,7 @@ const CountryList = props => {
 if (environment !== 'production') {
   CountryList.propTypes = {
     appealStats: T.object,
-    countries: T.object
+    countries: T.array
   };
 }
 

--- a/src/root/views/region.js
+++ b/src/root/views/region.js
@@ -353,7 +353,7 @@ if (environment !== 'production') {
     personnel: T.object,
     keyFigures: T.object,
     snippets: T.object,
-    countries: T.object
+    countries: T.array
   };
 }
 


### PR DESCRIPTION
If the selected language doesn't have a translation for all the listed countries it gave an error `cannot read property [0] of null` at https://github.com/IFRCGo/go-frontend/blob/f93c1b1dcc3035827fa205166871aebe97b8b6df/src/root/components/country-list.js#L32