### PR TITLE
fix for translating Regions string in nav header

### DIFF
--- a/src/root/components/header-region-button.js
+++ b/src/root/components/header-region-button.js
@@ -5,6 +5,7 @@ import { environment } from '#config';
 import { PropTypes as T } from 'prop-types';
 import { regionsByIdSelector, regionByIdOrNameSelector } from '../selectors';
 import { connect } from 'react-redux';
+import LanguageContext from '#root/languageContext';
 
 // const regionArray = Object.keys(regions).map(k => regions[k]);
 
@@ -24,8 +25,9 @@ class HeaderRegionButton extends React.Component {
   }
 
   render () {
+    const { strings } = this.context; 
     const { currentPath, regions = {}, thisRegion } = this.props;
-    const title = thisRegion ? thisRegion.label : 'Regions';
+    const title = thisRegion ? thisRegion.label : strings.regionOverviewTitle;
     const triggerClassName = this.decideTriggerClassName(currentPath);
     const regionLinks = Object.values(regions).map(r => {
       r = r[0];
@@ -64,6 +66,8 @@ if (environment !== 'production') {
     currentPath: T.object
   };
 }
+
+HeaderRegionButton.contextType = LanguageContext;
 
 const selector = (state, ownProps) => ({
   regions: regionsByIdSelector(state),

--- a/src/root/components/header-region-button.js
+++ b/src/root/components/header-region-button.js
@@ -27,7 +27,7 @@ class HeaderRegionButton extends React.Component {
   render () {
     const { strings } = this.context; 
     const { currentPath, regions = {}, thisRegion } = this.props;
-    const title = thisRegion ? thisRegion.label : strings.regionOverviewTitle;
+    const title = thisRegion ? thisRegion.label : strings.menuRegions;
     const triggerClassName = this.decideTriggerClassName(currentPath);
     const regionLinks = Object.values(regions).map(r => {
       r = r[0];

--- a/src/root/lang.js
+++ b/src/root/lang.js
@@ -29,6 +29,7 @@ export default {
   menuEmergencies: 'Emergencies',
   menuDeployments: 'Deployments',
   menuPreparedness: 'Preparedness',
+  menuRegions: 'Regions',
 
   aboutTitle: 'IFRC Go - About',
   aboutResources: 'Resources',


### PR DESCRIPTION
@frozenhelium let me know if you'd rather I create a new variable in lang.js instead of re-using the regionsOverview string.

cc @GregoryHorvath 
