### PR TITLE
fix display of emergency name in alerts table emergency link

### DIFF
--- a/src/root/components/connected/alerts-table.js
+++ b/src/root/components/connected/alerts-table.js
@@ -164,10 +164,11 @@ class AlertsTable extends SFPComponent {
     const rows = data.results.reduce((acc, rowData, idx, all) => {
       const date = DateTime.fromISO(rowData.created_at);
       const event = get(rowData, 'event.id');
+      const eventTitle = rowData.operation || get(rowData, 'event.name');
       acc.push({
         id: rowData.id,
         date: date.toISODate(),
-        emergency: event ? <Link className='link--table' to={`/emergencies/${event}`} title={strings.alertTableViewEmergency}>{rowData.operation}</Link> : rowData.operation || nope,
+        emergency: event ? <Link className='link--table' to={`/emergencies/${event}`} title={strings.alertTableViewEmergency}>{eventTitle}</Link> : rowData.operation || nope,
 
         msg: isLoggedIn(this.props.user) ? <Expandable limit={128} text={rowData.message} /> : privateSurgeAlert,
         type: this.getAlertTypes(strings)[rowData.atype],


### PR DESCRIPTION
Fixes display of the Emergency names in the Alerts table for Alerts imported from Molnix (uses the name of the emergency if operation string is empty).

