### PR TITLE
add custom additional tab label for country page

### DIFF
--- a/src/root/views/countries.js
+++ b/src/root/views/countries.js
@@ -150,6 +150,7 @@ class AdminArea extends SFPComponent {
   }
 
   getTabDetails = (strings) => {
+    const additionalTabName = get(this.props.adminArea, 'data.additional_tab_name') || strings.countryAdditionalInfoTab;
     const tabDetails = [
       {
         title: strings.countryOperationsTab,
@@ -170,7 +171,7 @@ class AdminArea extends SFPComponent {
         hash: '#preparedness'
       },
       {
-        title: strings.countryAdditionalInfoTab,
+        title: additionalTabName,
         hash: '#additional'
       },
     ];


### PR DESCRIPTION
Refs #1621 - allows Additional Info tab name on country page to be customized in the backend.