### PR TITLE
Region additional tab fixes

### DIFF
--- a/src/root/components/admin-area-elements.js
+++ b/src/root/components/admin-area-elements.js
@@ -72,9 +72,10 @@ class _Snippets extends React.Component {
   render () {
     const { strings } = this.context;
     const { fetching, fetched, error, data } = this.props.data;
+    const title = this.props.title || strings.snippetsTitle;
     if (fetching || error || (fetched && !data.results.length)) return null;
     return (
-      <Fold id='graphics' title={strings.snippetsTitle} foldWrapperClass='additional-graphics'>
+      <Fold id='graphics' title={title} foldWrapperClass='additional-graphics'>
         <div className='iframe__container'>
           {data.results.map(o => o.snippet ? <div className='snippet__item' key={o.id} dangerouslySetInnerHTML={{__html: o.snippet}} />
             : o.image ? <div key={o.id} className='snippet__item snippet__image'><img src={o.image}/></div> : null

--- a/src/root/lang.js
+++ b/src/root/lang.js
@@ -149,6 +149,7 @@ export default {
   regionProfileTab: 'Regional Profile',
   regionPreparednessTab: 'Preparedness',
   regionAdditionalInfoTab: 'Additional Data',
+  regionSnippetsTitle: 'Regional Content',
   regionIframeBackLink: 'Back to Regional Profile',
 
   regionalTabBox1: 'National Societies in Africa',

--- a/src/root/lang.js
+++ b/src/root/lang.js
@@ -152,7 +152,7 @@ export default {
   regionSnippetsTitle: 'Regional Content',
   regionIframeBackLink: 'Back to Regional Profile',
 
-  regionalTabBox1: 'National Societies in Africa',
+  regionalTabBox1: 'National Societies in {regionName}',
   regionalTabBox2: 'National Country Clusters',
   regionalTabBoxSource: 'Source: IFRC',
 

--- a/src/root/views/region.js
+++ b/src/root/views/region.js
@@ -445,9 +445,11 @@ class AdminArea extends SFPComponent {
                 </TabPanel>) : null }
 
                 <TabPanel>
+                  {/*
                   <TabContent isError={!get(this.props.keyFigures, 'data.results.length')} errorMessage={ strings.noDataMessage } title={strings.regionKeyFigures}>
                     <KeyFigures data={this.props.keyFigures} />
                   </TabContent>
+                  */}
                   <TabContent isError={!get(this.props.snippets, 'data.results.length')} errorMessage={ strings.noDataMessage } title={strings.regionGraphics}>
                     <Snippets data={this.props.snippets} title={strings.regionSnippets} />
                   </TabContent>

--- a/src/root/views/region.js
+++ b/src/root/views/region.js
@@ -449,7 +449,7 @@ class AdminArea extends SFPComponent {
                     <KeyFigures data={this.props.keyFigures} />
                   </TabContent>
                   <TabContent isError={!get(this.props.snippets, 'data.results.length')} errorMessage={ strings.noDataMessage } title={strings.regionGraphics}>
-                    <Snippets data={this.props.snippets} />
+                    <Snippets data={this.props.snippets} title={strings.regionSnippets} />
                   </TabContent>
                 </TabPanel>
               </div>

--- a/src/root/views/region.js
+++ b/src/root/views/region.js
@@ -391,7 +391,7 @@ class AdminArea extends SFPComponent {
                                   <div className='sumstats__value'>{data.national_society_count}</div>
                                 </div>
                                 <div className='col'>
-                                  <div className='regional-profile-subtitle'>{strings.regionalTabBox1}</div>
+                                  <div className='regional-profile-subtitle'>{resolveToString(strings.regionalTabBox1, { regionName })}</div>
                                 </div>
                               </div>
                               <div className='row flex regional-profile-icon-block'>

--- a/src/root/views/region.js
+++ b/src/root/views/region.js
@@ -223,11 +223,12 @@ class AdminArea extends SFPComponent {
       });
     }
 
-    // Add Additional Tab with custom name, FIXME: dont add if no data
-    tabDetails.push({
-      title: additionalTabName,
-      hash: '#additional-info'
-    });
+    if (get(this.props.snippets, 'data.results.length')) {
+      tabDetails.push({
+        title: additionalTabName,
+        hash: '#additional-info'
+      });
+    }
 
     const presentationClass = c({
       'presenting fold--stats': this.state.fullscreen,
@@ -444,6 +445,7 @@ class AdminArea extends SFPComponent {
                   </TabContent>
                 </TabPanel>) : null }
 
+                { get(this.props.snippets, 'data.results.length') ? (
                 <TabPanel>
                   {/*
                   <TabContent isError={!get(this.props.keyFigures, 'data.results.length')} errorMessage={ strings.noDataMessage } title={strings.regionKeyFigures}>
@@ -453,7 +455,7 @@ class AdminArea extends SFPComponent {
                   <TabContent isError={!get(this.props.snippets, 'data.results.length')} errorMessage={ strings.noDataMessage } title={strings.regionGraphics}>
                     <Snippets data={this.props.snippets} title={strings.regionSnippets} />
                   </TabContent>
-                </TabPanel>
+                </TabPanel>) :null }
               </div>
             </div>
           </Tabs>


### PR DESCRIPTION
Fixes a few small things as per #1621 -

 - Fix region name in label for national societies count
 - Change Additional Graphics to Regional Content in Additional Data tab
 - Hide Key figures
 - Hides the Additional Info tab if it contains no data

cc @GregoryHorvath 