### PR TITLE
debounce map mousemove, also comment out old districts mousemove fn

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "local-storage": "^1.4.2",
     "lodash": "^4.17.12",
     "lodash.clonedeep": "^4.5.0",
+    "lodash.debounce": "^4.0.8",
     "lodash.defaultsdeep": "^4.6.1",
     "lodash.filter": "^4.6.0",
     "lodash.find": "^4.6.0",

--- a/src/root/components/map/main-map.js
+++ b/src/root/components/map/main-map.js
@@ -3,6 +3,7 @@ import { render } from 'react-dom';
 import { PropTypes as T } from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import mapboxgl from 'mapbox-gl';
+import _debounce from 'lodash.debounce';
 import chroma from 'chroma-js';
 import { environment } from '#config';
 import BlockLoading from '../block-loading';
@@ -39,6 +40,7 @@ class MainMap extends React.Component {
       selectedDtype: null,
       mapActions: [],
       ready: false,
+      selectedFeatureISO: '',
       filters: {
         startDate: '',
         endDate: ''
@@ -194,22 +196,23 @@ class MainMap extends React.Component {
       theMap.getCanvas().style.cursor = '';
     });
 
-    theMap.on('mousemove', 'district', e => {
-      const id = get(e, 'features.0.properties.OBJECTID').toString();
-      if (id && get(this.props, 'deployments.data.areas', []).find(d => d.id === id)) {
-        theMap.getCanvas().style.cursor = 'pointer';
-      } else {
-        theMap.getCanvas().style.cursor = '';
-      }
-    });
+    // theMap.on('mousemove', 'district', e => {
+    //   const id = get(e, 'features.0.properties.OBJECTID').toString();
+    //   if (id && get(this.props, 'deployments.data.areas', []).find(d => d.id === id)) {
+    //     theMap.getCanvas().style.cursor = 'pointer';
+    //   } else {
+    //     theMap.getCanvas().style.cursor = '';
+    //   }
+    // });
 
-    theMap.on('mousemove', 'icrc_admin0', e => {
+    theMap.on('mousemove', 'icrc_admin0', _debounce(e => {
       const feature = e.features.length ? e.features[0] : undefined;
-      if (feature) {
+      if (feature && feature.properties.ISO2 !== this.state.selectedFeatureISO) {
+        this.setState({ selectedFeatureISO: feature.properties.ISO2 });
         theMap.setLayoutProperty('icrc_admin0_highlight', 'visibility', 'visible');
         theMap.setFilter('icrc_admin0_highlight', ['==', 'OBJECTID', feature.properties.OBJECTID]);
       }
-    });
+    }, 80));
 
     theMap.on('click', 'icrc_admin0', e => {
       console.log('features', e.features);


### PR DESCRIPTION
Should fix the jankiness when mousing over the map and highlighting countries.

@geohacker -

I commented out a mousemove on the districts layer, which was trying to change the mouse pointer, I think we should avoid that, and I don't think we are really using that, could you check if that looks okay?

I tried playing around with the debounce time a bit - 80ms seemed a good balance point on my machine where it didn't take too long to highlight a country, and there is little or no "jankiness" that existed without the debounce (or seems to exist a bit if I go to say 40ms).

I also added the current highlighted feature to the state and then doing a check, if it's the same feature being moused over, don't call the setFilter etc.. @geohacker can you look if that makes sense?

This definitely feels like a significant improvement for me, if the code looks good, I say let's merge.