### PR TITLE
Fix loop var declaration in timeline charts and add docs

### DIFF
--- a/src/root/components/timeline-charts.js
+++ b/src/root/components/timeline-charts.js
@@ -125,17 +125,19 @@ class TimelineCharts extends React.Component {
     });
 
     // Deal with missing months
+    // We take the min and max month from the data, and use a month by month for loop:
+    // If the loop index date is not in the data, then add a new entry in the 'data' array
+    // with empty drefs and appeals data
     const dates = dataDrefs.map(({ timespan }) => DateTime.fromISO(timespan, { zone: 'utc' }));
-    let curDate = DateTime.min(...dates);
+    const minDate = DateTime.min(...dates);
     const maxDate = DateTime.max(...dates);
-    while (curDate < maxDate) {
+    for (let curDate = minDate; curDate < maxDate; curDate = curDate.plus({ months: 1})) {
       if (!find(dates, d => d.equals(curDate))) {
         data.push({ timespan: curDate.toISODate({ zone: 'utc'}), drefs: { count: 0 }, appeals: { count: 0 }});
       }
-      curDate = curDate.plus({ months: 1});
     }
 
-    // sort by date
+    // Sort by date
     data = sortBy(data, [o => DateTime.fromISO(o.timespan, { zone: 'utc'}).ts]);
 
     return (


### PR DESCRIPTION
Fix for:

```
IFRCGo/go-frontend/src/root/components/timeline-charts.js
  132:24  warning  Function declared in a loop contains unsafe references to variable(s) 'curDate'  no-loop-func
```

by creating a new scoped variable for the internal for loop
