### PR TITLE
Hides field report map

### DIFF
--- a/src/root/views/emergency.js
+++ b/src/root/views/emergency.js
@@ -977,7 +977,8 @@ class Emergency extends React.Component {
       if (
         data.countries.length === 1 &&
         data.countries[0].record_type === 1 &&
-        data.districts.length > 0
+        data.districts.length > 0 &&
+        !data.hide_field_report_map
       ) {
         return (
           <div className='col-lg flex-1'>


### PR DESCRIPTION
Given API response that contains the boolean field hide_field_report_map hide the Map component from the page.
Depends on https://github.com/IFRCGo/go-api/pull/962