### PR TITLE
Fix nullchecking showHeader prop for DisplayTable

### DIFF
--- a/src/root/components/display-table.js
+++ b/src/root/components/display-table.js
@@ -72,7 +72,7 @@ export default class DisplayTable extends React.Component {
   }
 
   render () {
-    const showHeader = this.props.showHeader ? this.props.showHeader : true;
+    const showHeader = this.props.hasOwnProperty('showHeader') ? this.props.showHeader : true;
     return (
       <React.Fragment>
         <table className={this.props.className}>

--- a/src/root/components/display-table.js
+++ b/src/root/components/display-table.js
@@ -72,7 +72,7 @@ export default class DisplayTable extends React.Component {
   }
 
   render () {
-    const showHeader = !!this.props.showHeader;
+    const showHeader = this.props.showHeader ? this.props.showHeader : true;
     return (
       <React.Fragment>
         <table className={this.props.className}>


### PR DESCRIPTION
Ref.: https://github.com/IFRCGo/go-frontend/issues/1749

## Changes
- Fix nullchecking `showHeader` prop for `DisplayTable`, now defaults to `true`