### PR TITLE
check if iso exists before checking equality

### DIFF
--- a/src/root/components/map/main-map.js
+++ b/src/root/components/map/main-map.js
@@ -259,7 +259,7 @@ class MainMap extends React.Component {
 
   // FIXME: move this to a utils
   getCountryFromIso(iso, countries) {
-    const country = countries.find(country => country.iso.toUpperCase() === iso && country.record_type === 1);
+    const country = countries.find(country => country.iso && country.iso.toUpperCase() === iso && country.record_type === 1);
     if (country) {
       return country;
     } else {


### PR DESCRIPTION
This is because with https://github.com/IFRCGo/go-api/pull/964 we will import a bunch of countries without iso.

cc @batpad 