### PR TITLE
Per/component labels

### DIFF
--- a/src/root/actions/index.js
+++ b/src/root/actions/index.js
@@ -620,7 +620,9 @@ export function getPerCountries () {
 
 export const GET_PER_AREAS = 'GET_PER_AREAS';
 export function getPerAreas (id = null, area_num = null) {
-  let filters = {};
+  let filters = {
+    limit: 500
+  };
   if (area_num) {
     filters.area_num = area_num;
   }
@@ -675,7 +677,9 @@ export function getPerQuestions (area_id = null) {
 
 export const GET_PER_COMPONENTS = 'GET_PER_COMPONENTS';
 export function getPerComponents (area_id = null) {
-  let filters = {};
+  let filters = {
+    limit: 500
+  };
   if (area_id) {
     filters.area_id = area_id;
   }

--- a/src/root/components/per-forms/per-form.js
+++ b/src/root/components/per-forms/per-form.js
@@ -45,7 +45,7 @@ function PerForm (props) {
 
   useEffect(() => {
     if (formsState && groupedPerQuestions) {
-      let perQuestions = groupedPerQuestions['groupedQuestions'][formsState[formId].area.area_num];
+      let perQuestions = groupedPerQuestions[formsState[formId].area.area_num];
 
       // If EPI benchmark is false remove the EPI questions
       if (isEpi === 'false') {
@@ -61,7 +61,15 @@ function PerForm (props) {
   if (formsState && !perComponents.fetching && perComponents.fetched && perComponents.data) {
     filteredComponents = perComponents.data.results
       .filter(comp => comp.area.area_num === formsState[formId].area.area_num)
-      .sort((a, b) => a.component_num < b.component_num);
+      .sort((a, b) => {
+        // First sort by component_num
+        if (a.component_num < b.component_num) return -1;
+        if (a.component_num > b.component_num) return 1;
+        // then by id
+        if (a.id < b.id) return -1;
+        if (a.id > b.id) return 1;
+        return 1;
+      });
   }
 
   return (

--- a/src/root/components/per-forms/per-form.js
+++ b/src/root/components/per-forms/per-form.js
@@ -89,7 +89,7 @@ function PerForm (props) {
           const questions = groupedQuestionList[comp.id]
             ? groupedQuestionList[comp.id].map((question) => (
               <div key={question.id}>
-                <h3>{comp.component_num}.{question.question_num} {question.question}</h3>
+                <h3>{comp.component_num}{!question.question_num ? comp.component_letter : ''}.{question.question_num} {question.question}</h3>
                 { question.description
                   ? (
                     <span className='rich-text-section' dangerouslySetInnerHTML={{__html: question.description}} />

--- a/src/root/selectors/index.js
+++ b/src/root/selectors/index.js
@@ -277,8 +277,8 @@ export const groupedPERQuestionsSelector = (state) => {
       'Not Reviewed': 2,
       'Does not exist': 3,
       'Partially exists': 4,
-      'Need improvements': 5,
-      'Exist, could be strengthened': 6,
+      'Needs improvement': 5,
+      'Exists, could be strengthened': 6,
       'High performance': 7
     };
 

--- a/src/root/selectors/index.js
+++ b/src/root/selectors/index.js
@@ -262,8 +262,8 @@ export const disasterTypesSelectSelector = (state) => {
   return [];
 };
 
-// area_nums > component_nums > questions
-export const formQuestionsSelector = (state) => {
+// area_nums > component_ids > questions
+export const groupedPERQuestionsSelector = (state) => {
   if (state.perQuestions && state.perQuestions.data.results) {
     // Custom sorting order, this was the cleanest way
     const answersOrder = {
@@ -277,38 +277,18 @@ export const formQuestionsSelector = (state) => {
       'High performance': 7
     };
 
-    // This was the original, but sorting keys were a big problem
-    // -- keeping it here if we ever want to use it
-    // const groupedQuestions = state.perQuestions.data.results.reduce((result, item) => {
-    //   item.answers.sort((a, b) => answersOrder[a.text_en] - answersOrder[b.text_en]);
-    //   const area = result[item.component.area.area_num] = result[item.component.area.area_num] || {};
-
-    //   const compNumLetter = `${item.component.component_num}${item.component.component_letter}`;
-    //   const comp = area[compNumLetter] = area[compNumLetter] || [];
-    //   comp.push({compNumLetter, question: item});
-    //   return result;
-    // }, {});
-
     const structuredObj = state.perQuestions.data.results.reduce((result, item) => {
-      const compNumLetter = `${item.component.component_num}${item.component.component_letter}`;
-
-      // Add an array of area_nums to the returned object
-      // const areas = result['areas'] = result['areas'] || [];
-      // if (!areas.includes(item.component.area.area_num)) {
-      //   areas.push(item.component.area.area_num);
-      // }
-
       const areas = result['areas'] = result['areas'] || {};
       const area = areas[item.component.area.area_num] = areas[item.component.area.area_num] || [];
-      if (!area.includes(compNumLetter)) {
-        area.push(compNumLetter);
+      if (!area.includes(item.component.id)) {
+        area.push(item.component.id);
       }
 
       item.answers.sort((a, b) => answersOrder[a.text_en] - answersOrder[b.text_en]);
       // Add the grouped questions (areas > components > questions) to the returned object
       const groupedQuestions = result['groupedQuestions'] = result['groupedQuestions'] || {};
       const ar = groupedQuestions[item.component.area.area_num] = groupedQuestions[item.component.area.area_num] || {};
-      const comp = ar[compNumLetter] = ar[compNumLetter] || [];
+      const comp = ar[item.component.id] = ar[item.component.id] || [];
       comp.push(item);
 
       return result;
@@ -316,6 +296,7 @@ export const formQuestionsSelector = (state) => {
 
     return structuredObj;
   }
+  return null;
 };
 
 export const disasterTypesSelector = (state) => {

--- a/src/root/views/per-assessment.js
+++ b/src/root/views/per-assessment.js
@@ -22,6 +22,7 @@ import { produce } from 'immer';
 import {
   getAssessmentTypes,
   getPerAreas,
+  getPerComponents,
   getPerQuestions,
   getPerOverviewStrict,
   getPerForms,
@@ -32,7 +33,7 @@ import {
   updatePerForms,
   resetPerState
 } from '#actions';
-import { formQuestionsSelector, nsDropdownSelector } from '#selectors';
+import { groupedPERQuestionsSelector, nsDropdownSelector } from '#selectors';
 import { showGlobalLoading, hideGlobalLoading } from '#components/global-loading';
 
 import Ajv from 'ajv';
@@ -112,6 +113,7 @@ function PerAssessment (props) {
   const {
     _getAssessmentTypes,
     _getPerAreas,
+    _getPerComponents,
     _getPerQuestions,
     _getPerOverviewStrict,
     _getPerForms,
@@ -231,6 +233,12 @@ function PerAssessment (props) {
   }, [_getPerAreas, props.perAreas]);
 
   useEffect(() => {
+    if (!props.perComponents || (!props.perComponents.fetched && !props.perComponents.fetching)) {
+      _getPerComponents();
+    }
+  }, [_getPerComponents, props.perComponents]);
+
+  useEffect(() => {
     const ats = props.perForm.assessmentTypes;
     if (!ats || (!ats.fetched && !ats.fetching)) {
       _getAssessmentTypes();
@@ -328,6 +336,7 @@ function PerAssessment (props) {
     const overviews = props.perOverview;
     const upo = props.perForm.updatePerOverview;
     const umpf = props.perForm.updateMultiplePerForms;
+    const pc = props.perComponents;
     if (!isCreate
       && !overviews.fetching
       && overviews.fetched
@@ -338,7 +347,10 @@ function PerAssessment (props) {
       && formDataState
       && props.groupedPerQuestions
       && !upo.fetching
-      && !umpf.fetching) {
+      && !umpf.fetching
+      && !pc.fetching
+      && pc.fetched
+      && pc.data) {
       hideGlobalLoading();
     }
   }, [
@@ -350,7 +362,8 @@ function PerAssessment (props) {
     props.perOverview,
     props.groupedPerQuestions,
     props.perForm.updatePerOverview,
-    props.perForm.updateMultiplePerForms
+    props.perForm.updateMultiplePerForms,
+    props.perComponents
   ]);
 
   useEffect(() => {
@@ -590,16 +603,18 @@ if (environment !== 'production') {
 const selector = (state, ownProps) => ({
   user: state.user.data,
   perAreas: state.perAreas,
+  perComponents: state.perComponents,
   perQuestions: state.perQuestions,
   perForm: state.perForm,
   perOverview: state.perOverview,
-  groupedPerQuestions: formQuestionsSelector(state),
+  groupedPerQuestions: groupedPERQuestionsSelector(state),
   nsDropdownItems: nsDropdownSelector(state)
 });
 
 const dispatcher = (dispatch) => ({
   _getAssessmentTypes: () => dispatch(getAssessmentTypes()),
   _getPerAreas: (...args) => dispatch(getPerAreas(...args)),
+  _getPerComponents: (...args) => dispatch(getPerComponents(...args)),
   _getPerQuestions: (...args) => dispatch(getPerQuestions(...args)),
   _getPerOverviewStrict: (...args) => dispatch(getPerOverviewStrict(...args)),
   _getPerForms: (...args) => dispatch(getPerForms(...args)),


### PR DESCRIPTION
Ref.: #1667 

## Changes
- Add limit filters to actions
- Use `perComponents` action/reducer to help categorize PER Questions by using the Component `id`s instead of their `component_num`s