### PR TITLE
#1775: Add styling for Affected Population Centres

### DIFF
--- a/src/root/views/emergency.js
+++ b/src/root/views/emergency.js
@@ -226,46 +226,46 @@ class Emergency extends React.Component {
           <div>
             <ul className='list-reset'>
               <li className='row spacing-half-v'>
-                <div className='col'>
+                <div className='col col-8'>
                   <Translate stringId="emergencyPotentiallyAffectedLabel" />
                 </div>
-                <div className='col margin-left-auto emergency__affected__no'>
+                <div className='col col-4 emergency__affected__no'>
                   <span className="base-font-semi-bold">
                     {n(numPotentiallyAffected)}
                   </span>
                 </div>
               </li>
               <li className='row flex spacing-half-v'>
-                <div className='col'>
+                <div className='col col-8'>
                   <Translate stringId="emergencyHighestRiskLabel" />
                 </div>
-                <div className='col margin-left-auto emergency__affected__no'>
+                <div className='col col-4 emergency__affected__no'>
                   <span className="base-font-semi-bold">{n(numHighestRisk)}</span>
                 </div>
               </li>
-              <li className='row flex spacing-half-v'>
-                <div className='col'>
+              <li className='row spacing-half-v emergency__affected__figures--pop'>
+                <div className='col col-12'>
                   <Translate stringId="emergencyAffectedPopulationCentresLabel" />
                 </div>
-                <div className='col margin-left-auto emergency__affected__no'>
+                <div className='col col-12 emergency__affected__no'>
                   <span className="base-font-semi-bold">{affectedPopCentres}</span>
                 </div>
               </li>
               <li className='row flex spacing-half-v'>
-                <div className='col'>
+                <div className='col col-8'>
                   <Translate stringId="emergencyAssistedByGovernmentLabel" />
                 </div>
-                <div className='col margin-left-auto emergency__affected__no'>
+                <div className='col col-4 emergency__affected__no'>
                   <span className="base-font-semi-bold">
                     {n(get(report, 'gov_num_assisted'))}
                   </span>
                 </div>
               </li>
               <li className='row flex spacing-half-v'>
-                <div className='col'>
+                <div className='col col-8'>
                   <Translate stringId="emergencyAssistedByRCRCLabel" />
                 </div>
-                <div className='col margin-left-auto emergency__affected__no'>
+                <div className='col col-4 emergency__affected__no'>
                   <span className="base-font-semi-bold">
                     {n(get(report, 'num_assisted'))}
                   </span>

--- a/src/styles/emergency/_global.scss
+++ b/src/styles/emergency/_global.scss
@@ -336,6 +336,16 @@ a.response__doc__item {
   li {
     width: 100%;  
     display: flex;
+
+    &.emergency__affected__figures--pop {
+      display: block;
+
+      .emergency__affected__no {
+        width: 100%;
+        text-align: inline-start;
+        margin-top: ($spacing-half / 2);
+      }
+    }
   }
 }
 


### PR DESCRIPTION
This PR moves the value for the Key Figures in an emergency to the next line, since that content can sometimes get quite lengthy.