### PR TITLE
Fix inconsistency between countryIds

### DIFF
--- a/src/root/views/countries.js
+++ b/src/root/views/countries.js
@@ -127,7 +127,7 @@ class AdminArea extends SFPComponent {
   }
 
   loadCountry (props, countryId, countries) {
-    this.getData(props);
+    this.getData(props, countryId);
     this.getAdmArea(props.type, countryId);
     this.props._getPerNsPhase(countryId);
     this.props._getPerOverviews(countryId);
@@ -188,16 +188,15 @@ class AdminArea extends SFPComponent {
     }
   }
 
-  getData (props) {
+  getData (props, countryId) {
     const type = 'country';
-    const id = this.props.country.id;
-    this.props._getAdmAreaAppealsList(type, id);
-    this.props._getAdmAreaKeyFigures(type, id);
-    this.props._getAdmAreaSnippets(type, id);
-    this.props._getCountryOperations(type, id);
-    this.props._getPartnerDeployments(type, id);
-    this.props._getFdrs(id);
-    this.props._getAppealsListStats({countryId: id});
+    this.props._getAdmAreaAppealsList(type, countryId);
+    this.props._getAdmAreaKeyFigures(type, countryId);
+    this.props._getAdmAreaSnippets(type, countryId);
+    this.props._getCountryOperations(type, countryId);
+    this.props._getPartnerDeployments(type, countryId);
+    this.props._getFdrs(countryId);
+    this.props._getAppealsListStats({countryId: countryId});
   }
 
   getAdmArea (type, id) {


### PR DESCRIPTION
No clue why this works since it's the same here: https://github.com/IFRCGo/go-frontend/blob/82fa1b547846fb59e57cf9b7539b7e63cccf35d4/src/root/views/countries.js#L147

...but it does somehow...

cc @batpad 