### PR TITLE
Release v4.5.1

### DIFF
--- a/src/root/lang.js
+++ b/src/root/lang.js
@@ -1268,7 +1268,7 @@ export default {
   emergencyRapidResponsePersonnel: 'Rapid Response Personnel',
   emergencyAffectedRegions: 'Affected Provinces',
   emergencySituationalOverviewTitle: 'Situational Overview',
-  emergencyAlertsTitle: 'Open Surge Positions',
+  emergencyAlertsTitle: 'Open Surge Alerts',
   emergencyPersonnelTitle: 'Personnel',
   emergencyERUTitle: 'ERUs',
   emergencyFieldReportsTitle: 'Field Reports',

--- a/src/root/views/countries.js
+++ b/src/root/views/countries.js
@@ -127,7 +127,7 @@ class AdminArea extends SFPComponent {
   }
 
   loadCountry (props, countryId, countries) {
-    this.getData(props);
+    this.getData(props, countryId);
     this.getAdmArea(props.type, countryId);
     this.props._getPerNsPhase(countryId);
     this.props._getPerOverviews(countryId);
@@ -188,16 +188,15 @@ class AdminArea extends SFPComponent {
     }
   }
 
-  getData (props) {
+  getData (props, countryId) {
     const type = 'country';
-    const id = this.props.country.id;
-    this.props._getAdmAreaAppealsList(type, id);
-    this.props._getAdmAreaKeyFigures(type, id);
-    this.props._getAdmAreaSnippets(type, id);
-    this.props._getCountryOperations(type, id);
-    this.props._getPartnerDeployments(type, id);
-    this.props._getFdrs(id);
-    this.props._getAppealsListStats({countryId: id});
+    this.props._getAdmAreaAppealsList(type, countryId);
+    this.props._getAdmAreaKeyFigures(type, countryId);
+    this.props._getAdmAreaSnippets(type, countryId);
+    this.props._getCountryOperations(type, countryId);
+    this.props._getPartnerDeployments(type, countryId);
+    this.props._getFdrs(countryId);
+    this.props._getAppealsListStats({countryId: countryId});
   }
 
   getAdmArea (type, id) {


### PR DESCRIPTION
### Release 4.5.1

#### Frontend

 - Change label 'Open Surge Positions' to 'Open Surge Alerts' - https://github.com/IFRCGo/go-frontend/issues/1638#issuecomment-745151831
 - Fix a bug where navigating from one Country page to another using Elasticsearch would retain some data from the previously visited Country - https://github.com/IFRCGo/go-frontend/issues/1788

#### Backend

 - Elasticsearch now will also pick up automatically generated (from Field Reports) Emergencies - https://github.com/IFRCGo/go-frontend/issues/989
 - Lowered Elasticsearch timeout value from `5` -> `2`, which makes it faster to retry in the case the first search request fails - https://github.com/IFRCGo/go-frontend/issues/989

#### TODOs
 - [ ] Deploy backend
 - [ ] Deploy frontend
 - [ ] Run `./manage.py index_elasticsearch` script on the backend to make sure every Emergency is being indexed