### PR TITLE
Allow login with email besides username

### DIFF
--- a/src/root/lang.js
+++ b/src/root/lang.js
@@ -101,7 +101,7 @@ export default {
   registerSubmitError: 'There are errors in the form. Please correct them before submitting again.',
   registerAccountPresent: 'Already have an account?',
   registerGotoLogin: 'Go to login page',
-  registerLogin: 'Log in.',
+  registerLogin: 'Login',
 
   loginTitle: 'IFRC Go - Login',
   loginHeader: 'Login',
@@ -121,7 +121,7 @@ export default {
   loginButton: 'Login',
   loginDontHaveAccount: 'Don’t have an account? ',
   loginCreateAccountTitle: 'Create new account',
-  loginSignUp: 'Sign Up.',
+  loginSignUp: 'Sign up',
   loginKeep: 'Keep me logged in',
 
   accountUserGreeting: 'Hello {user}',

--- a/src/root/lang.js
+++ b/src/root/lang.js
@@ -246,7 +246,7 @@ export default {
   recoverUsernameSubmitText: 'Send me my username',
 
   resendValidationTitle: 'IFRC Go - Re-send Validation Email',
-  resendValidationUsername: 'Enter the username you used during registration',
+  resendValidationUsername: 'Enter the email/username you used during registration',
   resendValidationUsernameLabel: 'Username',
   resendValidationSubmitText: 'Re-send',
 

--- a/src/root/lang.js
+++ b/src/root/lang.js
@@ -105,7 +105,9 @@ export default {
 
   loginTitle: 'IFRC Go - Login',
   loginHeader: 'Login',
+  loginSubHeader: 'If you are staff, member or volunteer of the Red Cross Red Crescent Movement (National Societies, the IFRC and the ICRC) login with you email and password.',
   loginUsername: 'Username',
+  loginEmailUsername: 'Email/Username',
   loginPassword: 'Password',
   loginRecoverTitle: 'Recover password',
   loginForgotPassword: 'I forgot my password.',
@@ -113,12 +115,14 @@ export default {
   loginForgotUsername: 'I forgot my username only.',
   loginResendValidation: 'Re-send validation email.',
   loginResendValidationTitle: 'I didn\'t get my validation email',
+  loginForgotUserPass: 'Forgot your password/username?',
   loginInvalid: 'Invalid username or password',
   loginErrorMessage: 'Error: {message}',
   loginButton: 'Login',
   loginDontHaveAccount: 'Don’t have an account? ',
   loginCreateAccountTitle: 'Create new account',
   loginSignUp: 'Sign Up.',
+  loginKeep: 'Keep me logged in',
 
   accountUserGreeting: 'Hello {user}',
 

--- a/src/root/schemas/register.js
+++ b/src/root/schemas/register.js
@@ -225,7 +225,7 @@ export default {
   },
   required: [
     'email',
-    'username',
+    // 'username',
     'organizationType',
     'organization',
     'firstname',

--- a/src/root/views/account.js
+++ b/src/root/views/account.js
@@ -92,7 +92,7 @@ const profileAttributes = [
   ['username'],
   ['first_name', 'firstName'],
   ['last_name', 'lastName'],
-  ['email'],
+  ['email', 'email'],
   ['profile.phone_number', 'phoneNumber'],
   ['profile.city', 'city'],
   ['profile.org', 'org'],
@@ -128,6 +128,7 @@ class Account extends React.Component {
       profile: {
         firstName: null,
         lastName: null,
+        email: null,
         city: null,
         org: null,
         orgType: null,
@@ -328,6 +329,7 @@ class Account extends React.Component {
   syncProfileState (data) {
     const profile = get(data, 'profile', {});
     const next = {
+      email: data.email || null,
       firstName: data.first_name || null,
       lastName: data.last_name || null,
       city: profile.city || null,
@@ -517,6 +519,15 @@ class Account extends React.Component {
               value={profile.lastName}
               onChange={this.onFieldChange.bind(this, 'profile', 'lastName')} >
             </FormInput>
+            <FormInput
+              label={strings.recoverAccountEmailLabel}
+              type='text'
+              name='email'
+              id='email'
+              classWrapper='form__group__fr'
+              value={profile.email}
+              onChange={this.onFieldChange.bind(this, 'profile', 'email')}
+            />
             <FormInput
               label={strings.accountPhoneNumber}
               type='text'

--- a/src/root/views/account.js
+++ b/src/root/views/account.js
@@ -521,7 +521,7 @@ class Account extends React.Component {
             </FormInput>
             <FormInput
               label={strings.recoverAccountEmailLabel}
-              type='text'
+              type='email'
               name='email'
               id='email'
               classWrapper='form__group__fr'

--- a/src/root/views/login.js
+++ b/src/root/views/login.js
@@ -153,7 +153,7 @@ class Login extends React.Component {
                   </p>
                 </FormInput>
                 {this.renderError()}
-                <hr/>
+                <hr />
                 <div className='form__footer text-center'>
                   <button
                     className={c('button button--primary-filled button--small', { disabled: !this.allowSubmit() })}
@@ -163,7 +163,7 @@ class Login extends React.Component {
                   </button>
                   <p>
                     <Translate stringId='loginDontHaveAccount' />
-                    <Link to='/register' title={strings.loginCreateAccountTitle}>
+                    <Link className='login-link' to='/register' title={strings.loginCreateAccountTitle}>
                       <Translate stringId='loginSignUp' />
                     </Link>
                   </p>

--- a/src/root/views/login.js
+++ b/src/root/views/login.js
@@ -145,11 +145,11 @@ class Login extends React.Component {
                     {/* <br/>
                     <Link to='/recover-username' title={strings.loginShowUsernameTitle}>
                       <span><Translate stringId='loginForgotUsername' /></span>
-                    </Link>
-                    <br/>
-                    <Link to='/resend-validation' title={strings.loginResendValidationTitle}>
-                      <span><Translate stringId='loginResendValidation' /></span>
                     </Link> */}
+                    <br/>
+                    <Link to='/resend-validation' className='text-underlined' title={strings.loginResendValidationTitle}>
+                      <span><Translate stringId='loginResendValidation' /></span>
+                    </Link>
                   </p>
                 </FormInput>
                 {this.renderError()}

--- a/src/root/views/login.js
+++ b/src/root/views/login.js
@@ -97,10 +97,10 @@ class Login extends React.Component {
         <Helmet>
           <title>{strings.loginTitle}</title>
         </Helmet>
-        <BreadCrumb crumbs={[
+        {/* <BreadCrumb crumbs={[
           {link: '/login', name: strings.breadCrumbLogin},
           {link: '/', name: strings.breadCrumbHome}
-        ]} />
+        ]} /> */}
         <section className='inpage'>
           <header className='inpage__header'>
             <div className='inner'>
@@ -114,10 +114,14 @@ class Login extends React.Component {
             </div>
           </header>
           <div className='inpage__body'>
-            <div className='inner container-lg'>
-              <form className='form form--centered' onSubmit={this.onSubmit}>
+            <div className='inner container-sm'>
+              <form className='form' onSubmit={this.onSubmit}>
+                <p className='inpage__subheader'>
+                  <Translate stringId='loginSubHeader' />
+                </p>
+
                 <FormInput
-                  label={strings.loginUsername}
+                  label={strings.loginEmailUsername}
                   type='text'
                   name='login-username'
                   id='login-username'
@@ -131,20 +135,30 @@ class Login extends React.Component {
                   name='login-password'
                   id='login-password'
                   value={this.state.data.password}
-                  onChange={this.onFieldChange.bind(this, 'password')} >
-
+                  onChange={this.onFieldChange.bind(this, 'password')}
+                >
+                  {/* TODO: keep me logged in */}
                   <p className='form__help'>
-                    <Link to='/recover-account' title={strings.loginRecoverTitle}><span><Translate stringId='loginForgotPassword' /></span></Link>
+                    <Link to='/recover-account' className='text-underlined' title={strings.loginRecoverTitle}>
+                      <span><Translate stringId='loginForgotUserPass' /></span>
+                    </Link>
+                    {/* <br/>
+                    <Link to='/recover-username' title={strings.loginShowUsernameTitle}>
+                      <span><Translate stringId='loginForgotUsername' /></span>
+                    </Link>
                     <br/>
-                    <Link to='/recover-username' title={strings.loginShowUsernameTitle}><span><Translate stringId='loginForgotUsername' /></span></Link>
-                    <br/>
-                    <Link to='/resend-validation' title={strings.loginResendValidationTitle}><span><Translate stringId='loginResendValidation' /></span></Link>
+                    <Link to='/resend-validation' title={strings.loginResendValidationTitle}>
+                      <span><Translate stringId='loginResendValidation' /></span>
+                    </Link> */}
                   </p>
                 </FormInput>
-
                 {this.renderError()}
-                <div className='form__footer'>
-                  <button className={c('mfa-tick', { disabled: !this.allowSubmit() })} type='submit' onClick={this.onSubmit}>
+                <hr/>
+                <div className='form__footer text-center'>
+                  <button
+                    className={c('button button--primary-filled button--small', { disabled: !this.allowSubmit() })}
+                    type='submit' onClick={this.onSubmit}
+                  >
                     <Translate stringId='loginButton' />
                   </button>
                   <p>

--- a/src/root/views/recover-account.js
+++ b/src/root/views/recover-account.js
@@ -99,11 +99,13 @@ class RecoverAccount extends React.Component {
             property='email'
           />
         </FormInput>
-        <button className={c('mfa-tick', { disabled: !this.allowSubmit() })} type='button' onClick={this.onSubmit}>
-          <span>
-            <Translate stringId='recoverAccountSubmitText' />
-          </span>
-        </button>
+        <div className='text-center'>
+          <button className={c('mfa-tick', { disabled: !this.allowSubmit() })} type='button' onClick={this.onSubmit}>
+            <span>
+              <Translate stringId='recoverAccountSubmitText' />
+            </span>
+          </button>
+        </div>
       </form>
     );
   }

--- a/src/root/views/register.js
+++ b/src/root/views/register.js
@@ -175,41 +175,6 @@ class Register extends React.Component {
     return email && isValidEmail(email.toLowerCase()) && !isWhitelistedEmail(email.toLowerCase(), whitelistedDomains);
   }
 
-  renderPasswordFields () {
-    const { strings } = this.context;
-    return (
-      <div className='form__hascol form__hascol--2'>
-        <FormInput
-          label={strings.registerPassword}
-          type='password'
-          name='register-password'
-          id='register-password'
-          classInput={getClassIfError(this.state.errors, 'password')}
-          value={this.state.data.password}
-          onChange={this.onFieldChange.bind(this, 'password')}
-        >
-          <FormError
-            errors={this.state.errors}
-            property='password'
-          />
-        </FormInput>
-        <FormInput
-          label={strings.registerConfirmPassword}
-          type='password'
-          name='register-password-conf'
-          id='register-password-conf'
-          classInput={getClassIfError(this.state.errors, 'passwordConf')}
-          value={this.state.data.passwordConf}
-          onChange={this.onFieldChange.bind(this, 'passwordConf')}
-        >
-          <FormError
-            errors={this.state.errors}
-            property='passwordConf'
-          />
-        </FormInput>
-      </div>
-    );
-  }
 
   renderAdditionalInfo () {
     const { strings } = this.context;
@@ -474,28 +439,41 @@ class Register extends React.Component {
                     property='email'
                   />
                 </FormInput>
-
-                <FormInput
-                  label={strings.registerUsername}
-                  type='text'
-                  name='register-username'
-                  id='register-username'
-                  classInput={getClassIfError(this.state.errors, 'username')}
-                  value={this.state.data.username}
-                  onChange={this.onFieldChange.bind(this, 'username')}
-                >
-                  <p className='text-italic'>
-                    <Translate stringId='registerUsernameInfo' />
-                  </p>
-                  <FormError
-                    errors={this.state.errors}
-                    property='username'
-                  />
-                </FormInput>
+                <div className='form__hascol form__hascol--2'>
+                  <FormInput
+                    label={strings.registerPassword}
+                    type='password'
+                    name='register-password'
+                    id='register-password'
+                    classInput={getClassIfError(this.state.errors, 'password')}
+                    value={this.state.data.password}
+                    onChange={this.onFieldChange.bind(this, 'password')}
+                  >
+                    <FormError
+                      errors={this.state.errors}
+                      property='password'
+                    />
+                  </FormInput>
+                  <FormInput
+                    label={strings.registerConfirmPassword}
+                    type='password'
+                    name='register-password-conf'
+                    id='register-password-conf'
+                    classInput={getClassIfError(this.state.errors, 'passwordConf')}
+                    value={this.state.data.passwordConf}
+                    onChange={this.onFieldChange.bind(this, 'passwordConf')}
+                  >
+                    <FormError
+                      errors={this.state.errors}
+                      property='passwordConf'
+                    />
+                  </FormInput>
+                </div>
+                <hr />
                 {this.renderAdditionalInfo()}
-                {this.renderPasswordFields()}
                 {this.renderContactRequest()}
-                <div className='form__footer'>
+                <hr />
+                <div className='form__footer text-center'>
                   {this.renderSubmitButton()}
                   {this.state.errors ?
                    <p className='form__error'>
@@ -505,7 +483,7 @@ class Register extends React.Component {
                   }
                   <p>
                     <Translate stringId='registerAccountPresent' />
-                    <Link to='/login' title={strings.registerGotoLogin}>
+                    <Link className='login-link' to='/login' title={strings.registerGotoLogin}>
                       <span>
                         <Translate stringId='registerLogin' />
                       </span>

--- a/src/root/views/resend-validation.js
+++ b/src/root/views/resend-validation.js
@@ -69,7 +69,7 @@ class ResendValidation extends React.Component {
           <Translate stringId='resendValidationUsername' />
         </p>
         <FormInput
-          label={strings.resendValidationUsernameLabel}
+          label={strings.loginEmailUsername}
           type='text'
           name='username'
           id='username'

--- a/src/styles/components/_common.scss
+++ b/src/styles/components/_common.scss
@@ -346,3 +346,8 @@
     margin-inline-end: 30px;
   }
 }
+
+.login-link {
+  @include link-underline;
+  padding-left: $spacing / 2;
+}

--- a/src/styles/global/_forms.scss
+++ b/src/styles/global/_forms.scss
@@ -959,9 +959,9 @@ label[for] {
 
 .form__help {
   text-align: right;
-  font-size: $font-size-sm;
+  // font-size: $font-size-sm;
   color: rgba($base-font-color, 0.48);
-  margin-top: $global-spacing / 2;
+  margin-top: $global-spacing;
 
   > *:last-child {
     margin-bottom: 0;

--- a/src/styles/global/_inpages.scss
+++ b/src/styles/global/_inpages.scss
@@ -13,6 +13,12 @@
     }
   }
 
+  &__subheader {
+    font-size: 0.75rem;
+    padding-top: $spacing-2;
+    margin-bottom: $spacing-2;
+  }
+
   &__nav {
     font-weight: $base-font-medium;
   }

--- a/src/styles/home/_global.scss
+++ b/src/styles/home/_global.scss
@@ -780,3 +780,7 @@
     margin-bottom: 0;
   }
 }
+
+.text-underlined {
+  text-decoration: underline;
+}


### PR DESCRIPTION
Ref.: https://github.com/IFRCGo/go-frontend/issues/1663
Backend PR needed: https://github.com/IFRCGo/go-api/pull/994

## Changes

- Added `email` besides `username` for logins
- Added email to be editable through the user's account page
- Removed `username` from new registrations
- Removed unnecessary functions from the login screen
- Tried to follow the design changes on Login and Registration pages

## TODOs / Notes
- [x] Validate if "Re-send validation email" functionality is really to be removed from the Login page
- "Keep me logged in" functionality is missing