### PR TITLE
Fix/1845 country dropdowns

### DIFF
--- a/src/root/utils/field-report-constants.js
+++ b/src/root/utils/field-report-constants.js
@@ -45,14 +45,9 @@ export const getVisibility = (strings) => [
 // directly in a select dropdown
 export const countries = (countries, independent=false) => {
   let countriesSelectList = [];
-  if (countries[0].hasOwnProperty('value') && countries[0].hasOwnProperty('label')) {
-    countriesSelectList = countries;
-  } else {
-    countriesSelectList = countries.map(country => ({ value: country.id, label: country.name }));
-  }
 
   // show only independent countries (country and region) (include countries with empty or unavailable 'independent' prop)
-  countriesSelectList = countries.filter(country => country.record_type === 1 || country.record_type === 3);
+  countriesSelectList = countries.filter(country => country.record_type === 1);
 
   if (independent) {
     countriesSelectList = countriesSelectList
@@ -61,6 +56,10 @@ export const countries = (countries, independent=false) => {
         || country.independent === undefined
         || country.independent === null)
       );
+  }
+
+  if (!countries[0].hasOwnProperty('value') && !countries[0].hasOwnProperty('label')) {
+    countriesSelectList = countries.map(country => ({ value: country.id, label: country.name }));
   }
 
   return [

--- a/src/root/views/ThreeW/project-form.js
+++ b/src/root/views/ThreeW/project-form.js
@@ -221,8 +221,8 @@ class ProjectForm extends React.PureComponent {
   }
 
   getCountryAndNationalSocietyOptions = (countries) => {
-    const countryList = getResultsFromResponse(countries);
-
+    let countryList = getResultsFromResponse(countries);
+    countryList = countryList.filter(c => c.independent !== false && c.record_type === 1);
     const nationalSocietyOptions = countryList
       .filter(d => d.society_name)
       .map(d => ({
@@ -231,10 +231,7 @@ class ProjectForm extends React.PureComponent {
       })).sort(compareString);
 
     const countryOptions = countryList
-      .filter(d => d.iso &&
-        // make sure either this country is explicitly independent or undefined or null. But not false.
-        (d.hasOwnProperty('independent') && (d.independent || d.independent === undefined || d.independent === null))
-      )
+      .filter(d => d.iso)
       .map(d => ({
         value: d.id,
         label: d.name,

--- a/src/root/views/register.js
+++ b/src/root/views/register.js
@@ -178,7 +178,7 @@ class Register extends React.Component {
 
   renderAdditionalInfo () {
     const { strings } = this.context;
-    const countriesList = countries(this.props.countries);
+    const countriesList = countries(this.props.countries, true);
     return (
       <div className='form__hascol form__hascol--2'>
         <div className='form__group'>


### PR DESCRIPTION
Refs #1845 

Fixes filters for country dropdowns for:

 - Field Report form
 - 3w Form (Reporting NS and Country)
 - Country field on Registration page

For the PER form, we still get `Disputed` as NS name, but @jhenshall, this is something you said you'd fix in the data?

cc @geohacker 