### PR TITLE
ensure filtering points on home-page removes points from the map

### DIFF
--- a/src/root/components/map/home-map/filtering/filtering-processor.js
+++ b/src/root/components/map/home-map/filtering/filtering-processor.js
@@ -9,12 +9,13 @@ export function filtering (geoJSON, comparator) {
       id: d.properties.id,
       name: d.properties.name,
       iso: d.properties.iso,
-      appeals: d.properties.appeals
+      appeals: appeals
     });
+    // console.log('properties', properties);
     return {
       geometry: d.geometry,
       properties
     };
-  });
+  }).filter(feature => feature.properties.appeals.length > 0);
   return { type: 'FeatureCollection', features };
 }

--- a/src/root/components/map/home-map/filtering/filtering-processor.js
+++ b/src/root/components/map/home-map/filtering/filtering-processor.js
@@ -11,7 +11,6 @@ export function filtering (geoJSON, comparator) {
       iso: d.properties.iso,
       appeals: appeals
     });
-    // console.log('properties', properties);
     return {
       geometry: d.geometry,
       properties


### PR DESCRIPTION
Fixes bug when filtering on home-page by Emergency Type would filter the appeal amounts, but not hide points on the map that did not have any appeals / emergencies with the filter applied.

This fixes it to hide points on the map if there are no appeals associated with the point after filtering.

cc @geohacker 