### PR TITLE
Hotfix/post enforce language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Release 5.1.2: Hotfix for Field Report language submission errors
+
+ - Implements a fix where users with non-english locales in their system / browser configuration were sometimes facing errors when submitting Field Reports
+
+
 ### Release 5.1.1: Hotfix for Field Report Title
 
 - Implements a hotfix for the field report title to be a required field

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "go-frontend",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "private": true,
   "devDependencies": {
     "@babel/core": "7.9.0",


### PR DESCRIPTION
Adds a Hotfix to fix an issue where some users faced errors while trying to submit field reports.

This fix ensures we over-ride any user locale settings that might have been auto-populating the `Accept-Language` header and for POST and PATCH requests, always set the language header to english.

