### PR TITLE
fix positioning of today line on surge table, refs #1837

### DIFF
--- a/src/root/components/connected/personnel-table.js
+++ b/src/root/components/connected/personnel-table.js
@@ -193,9 +193,9 @@ class PersonnelTable extends SFPComponent {
       const midDate = DateTime.fromMillis((minDate.ts + maxDate.ts) / 2);
       const currDate = DateTime.utc();
       const totalDuration = maxDate.ts - minDate.ts;
-      const currPercent = ((currDate.ts - minDate.ts) / totalDuration) * 100;
+      const currPercent = parseInt(((currDate.ts - minDate.ts) / totalDuration) * 100);
       const rows = data.results.map(o => {
-        const progressValues = getProgressValues(minDate.ts, maxDate.ts, DateTime.fromISO(o.start_date).ts, DateTime.fromISO(o.end_date).ts);
+      const progressValues = getProgressValues(minDate.ts, maxDate.ts, DateTime.fromISO(o.start_date).ts, DateTime.fromISO(o.end_date).ts);
         return {
           id: o.id,
           //startDateInterval: DateTime.fromISO(o.start_date).toISODate(),
@@ -262,13 +262,13 @@ class PersonnelTable extends SFPComponent {
               resource='api/v2/personnel'
             />
           ) : null}
-          <div className='personnel__table__date__current' style={{paddingInlineStart: `${currPercent}%`}}>
-            <div className='personnel__date__current'>
+          <div className='personnel__table__date__current'>
+            <div className='personnel__date__current' style={{paddingInlineStart: `${currPercent}%`}}>
               {formatDateSlashes(currDate)}
             </div>
           </div>
-          <div className='personnel__date__graphic__block' style={{marginInlineStart: `${currPercent}%`}}>
-            <div className='personnel__date__graphic'>
+          <div className='personnel__date__graphic__block'>
+            <div className='personnel__date__graphic' style={{marginInlineStart: `${currPercent}%`}}>
             </div>
           </div>
           <DisplayTable

--- a/src/styles/components/_common.scss
+++ b/src/styles/components/_common.scss
@@ -242,6 +242,7 @@
   
 .table__cell--progress__personnel {
   width: 40%;
+  padding-inline-start: 0;
 }
 
 .progress__block__personnel {
@@ -340,16 +341,6 @@
   background-size: 2px 100%;
   background-repeat:no-repeat;
   width: 1px;
-}
-
-.personnel__table__date {
-  &:first-of-type {
-    margin-inline-start: -30px;
-  }
-
-  &:last-of-type {
-    margin-inline-end: 30px;
-  }
 }
 
 .login-link {


### PR DESCRIPTION
Fixes the positioning of the line representing "today" on the Personnel Deployments table / chart, refs #1837. This is a visual / CSS fix and should be safe to merge in.

@frozenhelium - could you give a review? Knowing that the overall code for this complex chart squeezed into the existing table structure is all a bit terrible - would be nice to have your eyes on it for a future refactor / to keep in mind whenever we are refactoring the tables and filters - for now, this just fixes the bug of the line appearing in the wrong place, so hopefully is fine to merge. Thanks!