### PR TITLE
fix mailto in emails on about page, refs #1980

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Release 5.2.2: Hotfix for incorrect emails on about page email links
+
+ - Fixes the mailto: values for emails on the About page to reflect the correct emails.
+
+
 ### Release 5.2.1: Hotfix for Field Report numeric field submission errors
 - Fix the positive integer condition in form (Restrict users to enter decimals in numbers)
 - Fix the "Dcoument" typo

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "go-frontend",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "private": true,
   "devDependencies": {
     "@babel/core": "7.9.0",

--- a/src/root/views/about.js
+++ b/src/root/views/about.js
@@ -383,7 +383,7 @@ function About (props) {
                           {contact.extent}
                         </div>
                         <div className='about__contact__col about__contact__name'>{contact.name}</div>
-                        <a href='mailto:rrim.africa@ifrc.org' className='about__contact__col about__contact__email'>{contact.email}</a>
+                        <a href={`mailto:${contact.email}`} className='about__contact__col about__contact__email'>{contact.email}</a>
                       </React.Fragment>
                     );
                   })}


### PR DESCRIPTION
Hotfix for #1980 - adds actual email addresses to the mailto field for emails on the About page.

