### PR TITLE
Miscellaneous fixes for surge alerts table

### DIFF
--- a/src/root/components/connected/alerts-table.js
+++ b/src/root/components/connected/alerts-table.js
@@ -27,6 +27,16 @@ import Expandable from '#components/expandable';
 import LanguageContext from '#root/languageContext';
 import Translate from '#components/Translate';
 
+
+// If alert comes from Molnix, only show first part of message as position.
+function getPositionString(alertRow) {
+  if (!alertRow.molnix_id) {
+    return alertRow.message;
+  } else {
+    return alertRow.message.split(',')[0];
+  }
+}
+
 class AlertsTable extends SFPComponent {
   // Methods form SFPComponent:
   // handlePageChange (what, page)
@@ -202,7 +212,7 @@ class AlertsTable extends SFPComponent {
         duration: getDuration(startDate, endDate),
 
         // for position, we only want first segment before a comma
-        position: rowData.message.split(',')[0],
+        position: getPositionString(rowData),
         keywords: getMolnixKeywords(rowData.molnix_tags),
         emergency: event ? <Link className='link--table' to={`/emergencies/${event}`} title={strings.alertTableViewEmergency}>{eventTitle}</Link> : rowData.operation || nope,
         country: country,

--- a/src/root/components/connected/personnel-table.js
+++ b/src/root/components/connected/personnel-table.js
@@ -223,7 +223,8 @@ class PersonnelTable extends SFPComponent {
           id: o.id,
           //startDateInterval: DateTime.fromISO(o.start_date).toISODate(),
           //endDate: DateTime.fromISO(o.end_date).toISODate(),
-          role: get(o, 'role', nope),
+          // display only first part before comma for role
+          role: o.role ? o.role.split(',')[0] : nope,
           type: o.type === 'rr' ? typeLongNames[o.type] : o.type.toUpperCase(),
           country: o.country_from ? getCountryDisplay(o.country_from, strings)  : nope,
           name: o.name,

--- a/src/root/utils/utils.js
+++ b/src/root/utils/utils.js
@@ -436,7 +436,7 @@ export function plural(singular, plural, number) {
  * @returns {String} - String - eg. "4 months"
  */
 export function getDuration(start, end) {
-  if (!start || !end) {
+  if (start.invalid || end.invalid) {
     return '';
   }
   const diff = end.diff(start, [

--- a/src/root/utils/utils.js
+++ b/src/root/utils/utils.js
@@ -436,17 +436,37 @@ export function plural(singular, plural, number) {
  * @returns {String} - String - eg. "4 months"
  */
 export function getDuration(start, end) {
+  if (!start || !end) {
+    return '';
+  }
   const diff = end.diff(start, [
     'months',
     'days'
   ]);
+
+  let months;
+  let days;
+
+  // Normalize to months when days are more than 25 or less than 5
+  if (diff.days > 25) {
+    months = months + 1;
+    days = 0;
+  } else if (diff.days < 5 && diff.months > 0) {
+    months = diff.months;
+    days = 0;
+  } else {
+    months = diff.months;
+    days = Math.round(diff.days);
+  }
+
   const daysString = plural('day', 'days', diff.days);
   const monthsString = plural('month', 'months', diff.months);
-  if (diff.months === 0) {
+
+  if (months === 0) {
     return `${diff.days} ${daysString}`;
   }
 
-  if (diff.days === 0) {
+  if (days === 0) {
     return `${diff.months} ${monthsString}`;
   }
 


### PR DESCRIPTION
- Fix bugs with display of duration:

    - Remove decimals
    - Round off to nearest month if days > 25 or < 5
    - If start date or end date do not exists, don't show NaN
 
- Only truncate Position field for Surge Alerts if coming from Molnix

- Add truncation for Position field for Deployments.

