### PR TITLE
Use default empty array for molinx-tags if not provided.

### DIFF
--- a/src/root/components/connected/alerts-table.js
+++ b/src/root/components/connected/alerts-table.js
@@ -213,7 +213,7 @@ class AlertsTable extends SFPComponent {
 
         // for position, we only want first segment before a comma
         position: getPositionString(rowData),
-        keywords: getMolnixKeywords(rowData.molnix_tags),
+        keywords: getMolnixKeywords(rowData.molnix_tags || []),
         emergency: event ? <Link className='link--table' to={`/emergencies/${event}`} title={strings.alertTableViewEmergency}>{eventTitle}</Link> : rowData.operation || nope,
         country: country,
         status: rowData.molnix_status === 'unfilled' ? 'Stood down' : 'Open' 


### PR DESCRIPTION
Address surge page not working because of missing molinx-tags from API.

NOTE: A hotfix has already been deployed to production (master). https://github.com/IFRCGo/go-frontend/pull/2001

Error page: https://go.ifrc.org/emergencies/5499#surge
![2021-08-16-144644](https://user-images.githubusercontent.com/7059255/129538664-2d390b5c-c409-423c-a408-5f6865c3c48f.png)
![2021-08-16-145321](https://user-images.githubusercontent.com/7059255/129539471-87fe8a4c-ee46-40b5-9c92-79d7d85d2604.png)
![2021-08-16-144633](https://user-images.githubusercontent.com/7059255/129538671-ef30a7ee-ebd7-458e-99ab-7fcffa7565c5.png)
