### PR TITLE
Do not filter out inactive alerts on All Alerts table

### DIFF
--- a/src/root/components/connected/alerts-table.js
+++ b/src/root/components/connected/alerts-table.js
@@ -117,6 +117,10 @@ class AlertsTable extends SFPComponent {
       qs.created_at__gte = recentInterval;
     }
 
+    if (props.isActive) {
+      qs.is_active = 'true';
+    }
+    
     if (!isNaN(props.emergency)) {
       qs.event = props.emergency.toString();
     }
@@ -264,7 +268,7 @@ if (environment !== 'production') {
     noPaginate: T.bool,
     showExport: T.bool,
     title: T.string,
-
+    isActive: T.bool,
     showRecent: T.bool,
     viewAll: T.string,
     viewAllText: T.string,

--- a/src/root/views/deployments.js
+++ b/src/root/views/deployments.js
@@ -276,6 +276,7 @@ class Deployments extends SFPComponent {
               <AlertsTable
                 title={strings.homeSurgeNotification}
                 limit={5}
+                isActive={true}
                 viewAll={'/alerts/all'}
                 showRecent={true}
               />

--- a/src/root/views/emergency.js
+++ b/src/root/views/emergency.js
@@ -1432,6 +1432,7 @@ class Emergency extends React.Component {
                   <TabContent title={strings.emergencyAlertsTitle}>
                     <SurgeAlertsTable
                       id="alerts"
+                      isActive={true}
                       title={strings.emergencyAlertsTitle}
                       emergency={this.props.match.params.id}
                       returnNullForEmpty={true}

--- a/src/root/views/table.js
+++ b/src/root/views/table.js
@@ -79,7 +79,11 @@ class Table extends React.Component {
         const title = props.hasOwnProperty('record')
           ? strings.operationsWithEmergency
           : resolveToString(strings.tableAppealsTitle, { title: titleArea, noun: noun });
-      return <AppealsTable title={title} {...props} />;
+      return (<AppealsTable
+        isActive={false}
+        title={title} 
+        {...props}
+      />);
       case 'alert':
       return <AlertsTable title={strings.tableAllAlertsTitle} {...props} />;
       case 'eru':


### PR DESCRIPTION
Depends on https://github.com/IFRCGo/go-api/pull/1170

Refs #1965 

Add is_active filter for the Surge Alerts table on the Deployments and Emergency pages - show all surge alerts on All Alerts page - depends on https://github.com/IFRCGo/go-api/pull/1170