### PR TITLE
v5.4.0: Surge + 3w Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+### Release 5.4.0: 3w Improvements + Surge / Deployments
+
+### Frontend:
+
+ - Re-write Deployments map: https://github.com/IFRCGo/go-frontend/pull/2012
+ - Add new chart for Deployments over the Past Year: https://github.com/IFRCGo/go-frontend/pull/2018
+ - Update Key Figures on Deployments page: https://github.com/IFRCGo/go-frontend/issues/2011
+ - Add Key Figures to Surge tab on Emergency page: https://github.com/IFRCGo/go-frontend/issues/2011
+ - Miscellaneous updates to Surge page and tables as per https://github.com/IFRCGo/go-frontend/issues/1965
+ - Various improvements to 3w as per https://github.com/IFRCGo/go-frontend/issues/1970
+
+### Backend:
+
+ - Backend changes for 3w as per https://github.com/IFRCGo/go-frontend/issues/1970
+ - Upgrade xml2dict library
+ - For Surge Alert API, by default return all Alerts, not only Active
+ - Fix aggregation count for Events by Deployment endpoint
+
 ### Release 5.3.3: Hotfixes
 
  - Fix link to GO User Library: https://github.com/IFRCGo/go-frontend/issues/1999

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Release 5.4.0: 3w Improvements + Surge / Deployments
 
+Date: 2021-09-07
+
 ### Frontend:
 
  - Re-write Deployments map: https://github.com/IFRCGo/go-frontend/pull/2012

--- a/README.md
+++ b/README.md
@@ -89,4 +89,4 @@ To add an icon:
  - Run `yarn run collecticons` to rebuild the icon font and re-generate the _collecticons.scss file, found in `src/styles/core/`. NOTE: Do NOT update this file by hand.
  - Use the added class in your React Markup to add the icon - this class name will be `collecticons-` + your SVG filename, so if your file was called `my-icon.svg`, the className to use will be `collecticons-my-icon`. Refer to existing code for usage examples.
  - Alternatively, you can use Icomoon to rebuild the icon font. First import the new SVG icons on the Icomoon site. Then upload the `selection.json` (src/assets/icons/icomoon/selection.json) file (which contains the icon settings) using the 'Import Icons' button. You can regenerate the font from Icomoon. For more instructions, see [Icomoon](https://icomoon.io/#docs).
- 
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "go-frontend",
-  "version": "5.3.3",
+  "version": "5.4.0",
   "private": true,
   "devDependencies": {
     "@babel/core": "7.9.0",

--- a/src/root/actions/index.js
+++ b/src/root/actions/index.js
@@ -587,6 +587,16 @@ export function getAllDeploymentERU (filters = {}) {
   };
 }
 
+export const GET_AGGR_SURGE_KEY_FIGURES = 'GET_AGGR_SURGE_KEY_FIGURES';
+export function getAggrSurgeKeyFigures () {
+  return fetchJSON(`/api/v2/deployment/aggregated`, GET_AGGR_SURGE_KEY_FIGURES, withToken());
+}
+
+export const GET_AGGR_SURGE_EVENT_KEY_FIGURES = 'GET_AGGR_SURGE_EVENT_KEY_FIGURES';
+export function getAggrSurgeEventKeyFigures (eventId) {
+  return fetchJSON(`/api/v2/deployment/aggregated?event=${eventId}`, GET_AGGR_SURGE_EVENT_KEY_FIGURES, withToken());
+}
+
 export const GET_LIST_CSV = 'GET_LIST_CSV';
 export function getListAsCsv (url, id) {
   return fetchCSV(url, GET_LIST_CSV, withToken(), { id });

--- a/src/root/components/Charts/index.js
+++ b/src/root/components/Charts/index.js
@@ -1,0 +1,45 @@
+import React from 'react';
+
+import { ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip } from 'recharts';
+import { DateTime } from 'luxon';
+import Translate from '#components/Translate';
+
+
+export const TimeLineChart = ({ data }) => {
+  const zone = 'utc';
+  const tickFormatter = (date) => DateTime.fromISO(date, {zone}).toFormat('MMM');
+  const contentFormatter = (payload) => {
+    if (!payload.payload[0]) { return null; }
+
+    const item = payload.payload[0].payload;
+    return (
+      <article className='chart-tooltip'>
+        <div className='chart-tooltip__contents'>
+          <dl>
+            <dd>
+              <Translate stringId='emergenciesDashDate' />
+            </dd>
+            <dt>{DateTime.fromISO(item.timespan, {zone}).toFormat('MMMM yyyy')}</dt>
+            <dd>
+              <Translate stringId='emergenciesDashTotal' />
+            </dd>
+            <dt>{item.count}</dt>
+          </dl>
+        </div>
+      </article>
+    );
+  };
+
+  return (
+    <div className='chart__container charts__container__rtl spacing-t'>
+      <ResponsiveContainer>
+        <LineChart data={data}>
+          <XAxis tickFormatter={tickFormatter} dataKey='timespan' axisLine={false} padding={{ left: 16, right: 16 }} />
+          <YAxis axisLine={false} tickLine={false} width={32} padding={{ bottom: 16 }} />
+          <Line type="monotone" dataKey="count" stroke="#f5333f" />
+          <Tooltip content={contentFormatter}/>
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};

--- a/src/root/components/ThreeWDetails/index.tsx
+++ b/src/root/components/ThreeWDetails/index.tsx
@@ -7,6 +7,7 @@ import {
 import LanguageContext from '#root/languageContext';
 import BlockLoading from '#components/block-loading';
 import Header from '#components/Header';
+import Translate from '#components/Translate';
 import TextOutput, { Props as TextOutputProps } from '#components/TextOutput';
 import { useRequest } from '#utils/restRequest';
 import { Project } from '#types';
@@ -79,6 +80,25 @@ function ProjectDetail(props: Props) {
     onSuccess: onProjectLoad,
   });
 
+  const displayName = React.useMemo(() => {
+    if (!projectResponse?.modified_by_detail) {
+      return undefined;
+    }
+
+    const {
+      username,
+      firstName,
+      lastName,
+    } = projectResponse.modified_by_detail;
+
+    if (firstName) {
+      return `${firstName} ${lastName}`;
+    }
+
+    return username;
+  }, [projectResponse?.modified_by_detail]);
+
+
   if (isNotDefined(projectId)) {
     return null;
   }
@@ -92,13 +112,19 @@ function ProjectDetail(props: Props) {
           heading={projectResponse?.name}
           actions={headerActions}
           descriptionClassName={styles.headerDescription}
-          description={(
+          description={ projectResponse ? (
             <TextOutput
               label={strings.threeWLastModifiedOn}
               value={projectResponse?.modified_at}
               valueType="date"
+              description={displayName ? (
+                <Translate
+                  stringId="threeWLastModifiedBy"
+                  params={{ user: displayName }}
+                />
+              ) : undefined}
             />
-          )}
+          ) : undefined }
         />
       )}
       {projectPending ? (

--- a/src/root/components/ThreeWForm/useThreeWOptions.ts
+++ b/src/root/components/ThreeWForm/useThreeWOptions.ts
@@ -140,9 +140,9 @@ export const schema: FormSchema = {
       visibility: [requiredCondition],
     };
 
-    const programmeType = value.programme_type;
-    const operationType = value.operation_type;
-    const projectStatus = value.status;
+    const programmeType = value?.programme_type;
+    const operationType = value?.operation_type;
+    const projectStatus = value?.status;
 
     if (operationType === OPERATION_TYPE_PROGRAMME) {
       schema.dtype = [];

--- a/src/root/components/connected/alerts-table.js
+++ b/src/root/components/connected/alerts-table.js
@@ -117,6 +117,10 @@ class AlertsTable extends SFPComponent {
       qs.created_at__gte = recentInterval;
     }
 
+    if (props.isActive) {
+      qs.is_active = 'true';
+    }
+    
     if (!isNaN(props.emergency)) {
       qs.event = props.emergency.toString();
     }
@@ -264,7 +268,7 @@ if (environment !== 'production') {
     noPaginate: T.bool,
     showExport: T.bool,
     title: T.string,
-
+    isActive: T.bool,
     showRecent: T.bool,
     viewAll: T.string,
     viewAllText: T.string,

--- a/src/root/components/connected/alerts-table.js
+++ b/src/root/components/connected/alerts-table.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { PropTypes as T, string } from 'prop-types';
+import { PropTypes as T } from 'prop-types';
 import { Link } from 'react-router-dom';
 import { DateTime } from 'luxon';
 
@@ -8,21 +8,18 @@ import { environment } from '#config';
 import { getSurgeAlerts } from '#actions';
 import { 
   get,
-  dateOptions,
   datesAgo,
-  isLoggedIn,
   getDuration,
   getMolnixKeywords 
 } from '#utils/utils';
-import { nope, privateSurgeAlert, recentInterval } from '#utils/format';
+import { nope, recentInterval } from '#utils/format';
 
 // FIXME: imports from the /components/ could be a 1 liner?
 import ExportButton from '#components/export-button-container';
 import { SFPComponent } from '#utils/extendables';
-import DisplayTable, { FilterHeader } from '#components/display-table';
+import DisplayTable from '#components/display-table';
 import BlockLoading from '#components/block-loading';
 import Fold from '#components/fold';
-import Expandable from '#components/expandable';
 
 import LanguageContext from '#root/languageContext';
 import Translate from '#components/Translate';

--- a/src/root/components/connected/all-personnel-table.js
+++ b/src/root/components/connected/all-personnel-table.js
@@ -86,9 +86,6 @@ class AllPersonnelTable extends SFPComponent {
     if (state.filters.startDateInterval !== 'all') {
       qs.start_date__gte = datesAgo[state.filters.startDateInterval]();
     }
-    if (state.filters.type !== 'all') {
-      qs.type = state.filters.type;
-    }
 
     if (!isNaN(props.emergency)) {
       qs.event_deployed_to = props.emergency;
@@ -141,10 +138,7 @@ class AllPersonnelTable extends SFPComponent {
         id: 'role',
         label: <SortHeader id='role' title={strings.personnelTableRole} sort={this.state.table.sort} onClick={this.handleSortChange.bind(this, 'table', 'role')} />
       },
-      {
-        id: 'type',
-        label: <FilterHeader id='type' title={strings.personnelTableType} options={typeOptions} filter={this.state.table.filters.type} onSelect={this.handleFilterChange.bind(this, 'table', 'type')} />
-      },
+      { id: 'type', label: strings.personnelTableType },
       {
         id: 'country',
         label: <SortHeader id='country_from' title={strings.personnelTableFrom} sort={this.state.table.sort} onClick={this.handleSortChange.bind(this, 'table', 'country_from')} />

--- a/src/root/components/connected/emergencies-dash.js
+++ b/src/root/components/connected/emergencies-dash.js
@@ -6,6 +6,7 @@ import { DateTime } from 'luxon';
 import { Link } from 'react-router-dom';
 import { environment } from '#config';
 import Stats from '#components/emergencies/stats';
+import { TimeLineChart } from '#components/Charts';
 import EmergenciesMap from '#components/map/emergencies-map';
 import Progress from '#components/progress';
 import BlockLoading from '#components/block-loading';
@@ -46,43 +47,6 @@ class EmergenciesDash extends React.Component {
     );
   }
 
-  renderChart (data) {
-    const zone = 'utc';
-    const tickFormatter = (date) => DateTime.fromISO(date, {zone}).toFormat('MMM');
-    const contentFormatter = (payload) => {
-      if (!payload.payload[0]) { return null; }
-
-      const item = payload.payload[0].payload;
-      return (
-        <article className='chart-tooltip'>
-          <div className='chart-tooltip__contents'>
-            <dl>
-              <dd>
-                <Translate stringId='emergenciesDashDate' />
-              </dd>
-              <dt>{DateTime.fromISO(item.timespan, {zone}).toFormat('MMMM yyyy')}</dt>
-              <dd>
-                <Translate stringId='emergenciesDashTotal' />
-              </dd>
-              <dt>{item.count}</dt>
-            </dl>
-          </div>
-        </article>
-      );
-    };
-
-    return (
-      <ResponsiveContainer>
-        <LineChart data={data}>
-          <XAxis tickFormatter={tickFormatter} dataKey='timespan' axisLine={false} padding={{ left: 16, right: 16 }} />
-          <YAxis axisLine={false} tickLine={false} width={32} padding={{ bottom: 16 }} />
-          <Line type="monotone" dataKey="count" stroke="#f5333f" />
-          <Tooltip content={contentFormatter}/>
-        </LineChart>
-      </ResponsiveContainer>
-    );
-  }
-
   renderByMonth () {
     if (!this.props.aggregate.month) return null;
 
@@ -100,7 +64,7 @@ class EmergenciesDash extends React.Component {
             <h2 className='fold__title'><Translate stringId='emergenciesDashOverLastYear' /></h2>
           </figcaption>
           <div className='chart__container charts__container__rtl'>
-            {this.renderChart(data, 'month')}
+            <TimeLineChart data={data} />
           </div>
         </figure>
       </div>

--- a/src/root/components/connected/personnel-table.js
+++ b/src/root/components/connected/personnel-table.js
@@ -127,9 +127,6 @@ class PersonnelTable extends SFPComponent {
     if (state.filters.startDateInterval !== 'all') {
       qs.start_date__gte = datesAgo[state.filters.startDateInterval]();
     }
-    if (state.filters.type !== 'all') {
-      qs.type = state.filters.type;
-    }
 
     if (!isNaN(props.emergency)) {
       qs.event_deployed_to = props.emergency;
@@ -180,10 +177,7 @@ class PersonnelTable extends SFPComponent {
         id: 'role',
         label: <SortHeader id='role' title={strings.personnelTableRole} sort={this.state.table.sort} onClick={this.handleSortChange.bind(this, 'table', 'role')} />
       },
-      {
-        id: 'type',
-        label: <FilterHeader id='type' title={strings.personnelTableType} options={typeOptions} filter={this.state.table.filters.type} onSelect={this.handleFilterChange.bind(this, 'table', 'type')} />
-      },
+      { id: 'type', label: strings.personnelTableType },
       {
         id: 'country',
         label: <SortHeader id='country_from' title={strings.personnelTableFrom} sort={this.state.table.sort} onClick={this.handleSortChange.bind(this, 'table', 'country_from')} />

--- a/src/root/lang.js
+++ b/src/root/lang.js
@@ -1514,6 +1514,7 @@ export default {
   deploymentsPageTitleSurge: 'Surge',
   deploymentsOverviewError: 'Error loading data',
   deploymentsRapidResponse: 'Rapid Response',
+  deployementsOverLastYear: 'Deployments over the last year',
 
   emergencySourceMessage: 'Source: {link}',
   emergencyFieldReportStatsHeading: 'Key Figures',

--- a/src/root/lang.js
+++ b/src/root/lang.js
@@ -732,7 +732,10 @@ export default {
   deploymentsOverviewTableHeaderOrg: 'Deploying Organization',
   deploymentsOverviewTableHeaderSurge: 'Surge Type',
   deploymentsOverviewTableHeaderNo: 'Number of Deployments',
-  deploymentsDeployedRR: 'Deployed Rapid Response',
+  deploymentsDeployedRR: 'Deployed Rapid Response',  // not used
+  deploymentsDeployedRRP: 'Deployed Rapid Response Personnel',
+  deploymentsNSProvidingRRP: 'NS Providing Rapid Response Personnel',  // not used
+  deploymentsDeplThisYear: 'Deployments This Year',
   deploymentsDeployedHeops: 'Deployed HEOPS',
   deploymentEruDeploymentTypes: 'ERU Deployment Types',
   deploymentNumber: 'Number of Deployments by NS',

--- a/src/root/lang.js
+++ b/src/root/lang.js
@@ -942,7 +942,7 @@ export default {
   threeWKeyFigureProgrammeTypeTitle: 'Programme Type',
   threeWKeyFigureOngoingProjectBudgetTitle: 'Total Budget (CHF) for Ongoing Projects',
   threeWKeyFigureStatusTitle: 'Project Status',
-  threeWKeyFigureCountryActivityTitle: 'Activities in Countries',
+  threeWKeyFigureCountryActivityTitle: 'Countries where NS has reported projects',
   threeWTopNoLoginMessage: 'To view all the project details, {loginLink} with your RCRC credentials',
   threeWBottomNoLoginMessage: 'If you are a member of RCRC Movement, login with your credentials to see more details.',
   threeWOngoingProjectsTitle: 'Ongoing Projects',
@@ -979,6 +979,7 @@ export default {
   threeWNSMapReportingNS: 'Reporting NS',
   threeWNSMapReceivingCountry: 'Receiving Country',
   threeWLastModifiedOn: 'Last Modified On',
+  threeWLastModifiedBy: 'by {user}',
 
   projectFormReportingNational: 'Reporting National Society *',
   projectFormReportingHelpText: 'Select National Society that is carrying out the activity.',

--- a/src/root/lang.js
+++ b/src/root/lang.js
@@ -447,6 +447,9 @@ export default {
   tableAllAlertsTitle: 'All Surge Alerts',
   tableAllEruTitle: 'All Deployed ERUs',
   tableAllPersonnel: 'All Deployed Personnel',
+  eruOnly: 'ERU only',
+  rrOnly: 'Rapid Response only',
+  mixedEruRr: 'Mixed',
 
   uhohPageNotFoundTitle: 'IFRC Go - Page not found',
   uhohPageNotFound: 'Page not found',

--- a/src/root/reducers/deployments.js
+++ b/src/root/reducers/deployments.js
@@ -26,6 +26,21 @@ function aggregated (state = initialState, action) {
   return state;
 }
 
+function aggregated1 (state = initialState, action) {
+  switch (action.type) {
+    case 'GET_AGGR_SURGE_EVENT_KEY_FIGURES_INFLIGHT':
+      state = stateInflight(state, action);
+      break;
+    case 'GET_AGGR_SURGE_EVENT_KEY_FIGURES_FAILED':
+      state = stateError(state, action);
+      break;
+    case 'GET_AGGR_SURGE_EVENT_KEY_FIGURES_SUCCESS':
+      state = stateSuccess(state, action);
+      break;
+  }
+  return state;
+}
+
 function eru (state = initialState, action) {
   switch (action.type) {
     case 'GET_DEPLOYMENT_ERU_INFLIGHT':
@@ -110,5 +125,6 @@ export default combineReducers({
   personnel,
   activePersonnel,
   allEru,
-  aggregated
+  aggregated,
+  aggregated1
 });

--- a/src/root/reducers/deployments.js
+++ b/src/root/reducers/deployments.js
@@ -80,53 +80,19 @@ const locationInitialState = {
   features: []
 };
 
-function locations (state = locationInitialState, action) {
+function allEru (state = locationInitialState, action) {
   switch (action.type) {
     case 'GET_ACTIVE_PERSONNEL_SUCCESS':
     case 'GET_ALL_DEPLOYMENT_ERU_SUCCESS':
-      state = parseLocations(state.features, action);
+      state = stateSuccess(state, action);
       break;
   }
   return state;
-}
-
-// TODO: This can be simplified a lot
-function parseLocations (existingFeatures, action) {
-  const allCountries = action.countries;
-  const isEru = action.type === 'GET_ALL_DEPLOYMENT_ERU_SUCCESS';
-  const results = get(action, 'data.results', []);
-  let countryPath = isEru ? 'deployed_to' : 'deployment.country_deployed_to';
-  const countries = _groupBy(results, countryPath + '.id');
-  let features = existingFeatures.slice();
-  for (let id in countries) {
-    let deployments = countries[id];
-    let values = isEru
-      ? deployments.reduce((acc, next) => {
-        acc.eru += next.equipment_units;
-        return acc;
-      }, {eru: 0})
-      : deployments.reduce((acc, next) => {
-        acc[next.type] += 1;
-        return acc;
-      }, {heop: 0, fact: 0, rdrt: 0});
-    let existingFeature = features.find(d => d.properties.id.toString() === id);
-    if (existingFeature) {
-      for (let type in values) {
-        existingFeature.properties[type] += values[type];
-      }
-    } else {
-      let country = get(deployments[0], countryPath);
-      const thisCentroid = getCountryMeta(country.id, allCountries).centroid || [0, 0];
-      thisCentroid.properties = Object.assign({eru: 0, heop: 0, fact: 0, rdrt: 0}, country, values);
-      features.push(thisCentroid);
-    }
-  }
-  return { type: 'FeatureCollection', features };
 }
 
 export default combineReducers({
   eru,
   personnel,
   activePersonnel,
-  locations
+  allEru
 });

--- a/src/root/reducers/deployments.js
+++ b/src/root/reducers/deployments.js
@@ -11,6 +11,21 @@ const initialState = {
   data: {}
 };
 
+function aggregated (state = initialState, action) {
+  switch (action.type) {
+    case 'GET_AGGR_SURGE_KEY_FIGURES_INFLIGHT':
+      state = stateInflight(state, action);
+      break;
+    case 'GET_AGGR_SURGE_KEY_FIGURES_FAILED':
+      state = stateError(state, action);
+      break;
+    case 'GET_AGGR_SURGE_KEY_FIGURES_SUCCESS':
+      state = stateSuccess(state, action);
+      break;
+  }
+  return state;
+}
+
 function eru (state = initialState, action) {
   switch (action.type) {
     case 'GET_DEPLOYMENT_ERU_INFLIGHT':
@@ -94,5 +109,6 @@ export default combineReducers({
   eru,
   personnel,
   activePersonnel,
-  allEru
+  allEru,
+  aggregated
 });

--- a/src/root/reducers/event.js
+++ b/src/root/reducers/event.js
@@ -87,24 +87,8 @@ function snippets (state = initialState, action) {
   return state;
 }
 
-function aggregated (state = initialState, action) {
-  switch (action.type) {
-    case 'GET_AGGR_SURGE_EVENT_KEY_FIGURES_INFLIGHT':
-      state = stateInflight(state, action);
-      break;
-    case 'GET_AGGR_SURGE_EVENT_KEY_FIGURES_FAILED':
-      state = stateError(state, action);
-      break;
-    case 'GET_AGGR_SURGE_EVENT_KEY_FIGURES_SUCCESS':
-      state = stateSuccess(state, action);
-      break;
-  }
-  return state;
-}
-
 export default combineReducers({
   eventList,
   event,
-  snippets,
-  aggregated
+  snippets
 });

--- a/src/root/reducers/event.js
+++ b/src/root/reducers/event.js
@@ -87,8 +87,24 @@ function snippets (state = initialState, action) {
   return state;
 }
 
+function aggregated (state = initialState, action) {
+  switch (action.type) {
+    case 'GET_AGGR_SURGE_EVENT_KEY_FIGURES_INFLIGHT':
+      state = stateInflight(state, action);
+      break;
+    case 'GET_AGGR_SURGE_EVENT_KEY_FIGURES_FAILED':
+      state = stateError(state, action);
+      break;
+    case 'GET_AGGR_SURGE_EVENT_KEY_FIGURES_SUCCESS':
+      state = stateSuccess(state, action);
+      break;
+  }
+  return state;
+}
+
 export default combineReducers({
   eventList,
   event,
-  snippets
+  snippets,
+  aggregated
 });

--- a/src/root/types/project.ts
+++ b/src/root/types/project.ts
@@ -3,6 +3,10 @@ import {
   DistrictMini,
 } from './country';
 
+import {
+  UserMini,
+} from './user';
+
 export interface Disaster {
   id: number;
   name: string;
@@ -59,6 +63,8 @@ export interface Project {
   event_detail: Event | null;
   id: number;
   modified_at: string;
+  modified_by: number | null;
+  modified_by_detail: UserMini | null;
   name: string;
   operation_type: number;
   operation_type_display: string;

--- a/src/root/types/user.ts
+++ b/src/root/types/user.ts
@@ -10,6 +10,13 @@ export interface Subscription {
   stype: number;
 }
 
+export interface UserMini {
+  id: number;
+  username: string;
+  firstName?: string;
+  lastName?: string;
+}
+
 export interface User {
   id: number;
   username: string;

--- a/src/root/utils/constants.js
+++ b/src/root/utils/constants.js
@@ -167,12 +167,6 @@ export const secondarySectorList = [
     color: '#a6d854',
     inputValue: '13',
   },
-  {
-    key: '14',
-    title: 'RCCE',
-    color: '#a6d854',
-    inputValue: '14',
-  },
 ];
 
 export const sectors = listToMap(sectorList, d => d.key, d => d.title);

--- a/src/root/utils/mergeDeployData.js
+++ b/src/root/utils/mergeDeployData.js
@@ -43,13 +43,16 @@ function groupEventsArray(arr) {
 }
 
 export function mergeDeployData(countries, eru, personnel) {
-  const eruByCountry = eru.map((i) => ({
-    country: i.deployed_to.iso,
-    country_id: i.deployed_to.id,
-    units: i.units,
-    name: i.event ? i.event.name : 'No detailed event',
-    id: i.event ? i.event.id : null
-  }));
+  const eruByCountry = eru
+    .filter((i) => i.deployed_to)
+    .map((i) => ({
+      country: i.deployed_to.iso,
+      country_id: i.deployed_to.id,
+      units: i.units,
+      name: i.event ? i.event.name : 'No detailed event',
+      id: i.event ? i.event.id : null
+    })
+  );
   const personnelByCountry = groupPersonalArray(
     personnel.map((i) => ({
       country: i.deployment.country_deployed_to.iso,
@@ -59,7 +62,6 @@ export function mergeDeployData(countries, eru, personnel) {
       id: i.deployment.event_deployed_to ? i.deployment.event_deployed_to.id : null,
     }))
   );
-  console.log(personnelByCountry);
   let newCountries = {};
   Object.assign(newCountries, countries);
 

--- a/src/root/utils/mergeDeployData.js
+++ b/src/root/utils/mergeDeployData.js
@@ -1,0 +1,125 @@
+function groupPersonalArray(arr) {
+   const res = [];
+   for (let i = 0; i < arr.length; i++) {
+      const ind = res.findIndex((el) => el.name === arr[i].name);
+      if(ind !== -1){
+         res[ind].personnel += 1;
+      } else {
+         res.push(arr[i]);
+      }
+   }
+   return res;
+}
+
+function groupEruArray(arr) {
+   const res = [];
+   for (let i = 0; i < arr.length; i++) {
+      const ind = res.findIndex((el) => el.name === arr[i].name);
+      if(ind !== -1){
+         res[ind].units += arr[i].units;
+      } else {
+         res.push(arr[i]);
+      }
+   }
+   return res;
+}
+
+function groupEventsArray(arr) {
+   const res = [];
+   for (let i = 0; i < arr.length; i++) {
+      const ind = res.findIndex((el) => el.name === arr[i].name);
+      if(ind !== -1){
+        // add zero values if it's undefined
+        if (res[ind].units === undefined) res[ind].units = 0;
+        if (res[ind].personnel === undefined) res[ind].personnel = 0;
+        // sum if value is valid
+        if (arr[i].units !== undefined) res[ind].units += arr[i].units;
+        if (arr[i].personnel !== undefined) res[ind].personnel += arr[i].personnel;
+      } else {
+         res.push(arr[i]);
+      }
+   }
+   return res;
+}
+
+export function mergeDeployData(countries, eru, personnel) {
+  const eruByCountry = eru.map((i) => ({
+    country: i.deployed_to.iso,
+    country_id: i.deployed_to.id,
+    units: i.units,
+    name: i.event ? i.event.name : 'No detailed event',
+    id: i.event ? i.event.id : null
+  }));
+  const personnelByCountry = groupPersonalArray(
+    personnel.map((i) => ({
+      country: i.deployment.country_deployed_to.iso,
+      country_id: i.deployment.country_deployed_to.id,
+      personnel: 1,
+      name: i.deployment.event_deployed_to ? i.deployment.event_deployed_to.name : 'No detailed event',
+      id: i.deployment.event_deployed_to ? i.deployment.event_deployed_to.id : null,
+    }))
+  );
+  console.log(personnelByCountry);
+  let newCountries = {};
+  Object.assign(newCountries, countries);
+
+  const resultCountries = newCountries.features.reduce((result, country) => {
+    // properties shouldn't be inside geometry, so delete it
+    delete country.geometry.properties;
+    // filter the ERU and Personnel of each country
+    const countryUnits = eruByCountry.filter(
+      (i) => i.country === country.properties.iso
+    );
+    const countryPersonnel = personnelByCountry.filter(
+      (i) => i.country === country.properties.iso
+    );
+
+    // set events and ERU units
+    if (countryUnits.length) {
+      country.properties.iso = countryUnits[0].country;
+      country.properties.events = groupEruArray(
+        countryUnits.map(({ name, id, units }) => ({ name, id, units }))
+      );
+    }
+    // set personnel events and its amount
+    if (countryPersonnel.length) {
+      country.properties.iso = countryPersonnel[0].country;
+      if (country.properties.events && country.properties.events.length) {
+        country.properties.events = country.properties.events.concat(
+          countryPersonnel.map(({ name, id, personnel }) => ({ name, id, personnel }))
+        );
+      } else {
+        country.properties.events = countryPersonnel.map(
+          ({ name, id, personnel }) => ({ name, id, personnel })
+        );
+      }
+    }
+
+    // reduce result
+    if (countryUnits.length || countryPersonnel.length) {
+      // merge duplicated events
+      country.properties.events = groupEventsArray(country.properties.events);
+      // sum the number of personnel by country
+      country.properties.personnel = country.properties.events.reduce(
+        (sum, i) => {
+          if (i.personnel) {
+            sum += i.personnel;
+          }
+          return sum;
+        },
+        0
+      );
+      // sum the number of eru by country
+      country.properties.units = country.properties.events.reduce((sum, i) => {
+        if (i.units) {
+          sum += i.units;
+        }
+        return sum;
+      }, 0);
+      result = result.concat([country]);
+    }
+    return result;
+  }, []);
+
+  return {type: 'FeatureCollection', features: resultCountries};
+}

--- a/src/root/utils/utils.js
+++ b/src/root/utils/utils.js
@@ -6,7 +6,7 @@ import isUndefined from 'lodash.isundefined';
 import _find from 'lodash.find';
 import _filter from 'lodash.filter';
 import * as EmailValidator from 'email-validator';
-import { DateTime, Duration } from 'luxon';
+import { DateTime } from 'luxon';
 import {
   isNotDefined,
   isFalsyString,

--- a/src/root/views/Country/ThreeW/InCountryProjects/Map/index.tsx
+++ b/src/root/views/Country/ThreeW/InCountryProjects/Map/index.tsx
@@ -349,7 +349,10 @@ function ThreeWMap(props: Props) {
           }}
         />
       </MapSource>
-      <MapBounds bounds={countryBounds} />
+      <MapBounds
+        // @ts-ignore
+        bounds={countryBounds}
+      />
       {clickedPointProperties?.lngLat && selectedDistrictProjectDetail && (
         <MapTooltip
           coordinates={clickedPointProperties.lngLat}

--- a/src/root/views/FieldReportForm/useFieldReportOptions.ts
+++ b/src/root/views/FieldReportForm/useFieldReportOptions.ts
@@ -211,8 +211,8 @@ export const schema: FormSchema = {
   }),
 
   validation: (value) => {
-    if (value.status === STATUS_EARLY_WARNING
-        && value.dtype === DISASTER_TYPE_EPIDEMIC) {
+    if (value?.status === STATUS_EARLY_WARNING
+        && value?.dtype === DISASTER_TYPE_EPIDEMIC) {
       return 'Early Warning / Early action cannot be selected when disaster type is Epidemic or vice-versa';
     }
 

--- a/src/root/views/GlobalThreeW/Charts/index.tsx
+++ b/src/root/views/GlobalThreeW/Charts/index.tsx
@@ -80,6 +80,7 @@ function ThreeWPieChart(props: PieChartProps) {
             position="outside"
             // @ts-ignore
             formatter={(v: number) => `${((100 * (v / total))).toFixed(1)}%`}
+            // @ts-ignore
             isAnimationActive={false}
           />
         </Pie>
@@ -180,6 +181,7 @@ function ThreeWBarChart(props: BarChartProps) {
       maxHeight={limitHeight ? 30 * chartData.length : undefined}
     >
       <BarChart
+        style={{ direction: 'ltr' }}
         layout="vertical"
         data={chartData}
         margin={limitHeight ? {

--- a/src/root/views/GlobalThreeW/Charts/index.tsx
+++ b/src/root/views/GlobalThreeW/Charts/index.tsx
@@ -55,6 +55,13 @@ function ThreeWPieChart(props: PieChartProps) {
           top: 30,
         }}
       >
+        <Tooltip
+          isAnimationActive={false}
+          allowEscapeViewBox={{
+            x: false,
+            y: false,
+          }}
+        />
         <Pie
           data={chartData}
           dataKey="value"
@@ -62,7 +69,7 @@ function ThreeWPieChart(props: PieChartProps) {
           startAngle={450}
           endAngle={90}
         >
-          { chartData.map((entry, index) => (
+          {chartData.map((entry, index) => (
             <Cell
               key={`cell-${index}`}
               fill={PIE_COLORS[index % PIE_COLORS.length]}
@@ -71,6 +78,7 @@ function ThreeWPieChart(props: PieChartProps) {
           <LabelList
             className={styles.pieLabel}
             position="outside"
+            // @ts-ignore
             formatter={(v: number) => `${((100 * (v / total))).toFixed(1)}%`}
             isAnimationActive={false}
           />
@@ -90,7 +98,7 @@ function ThreeWPieChart(props: PieChartProps) {
   );
 }
 
-function CustomYAxisTick (props: {
+function CustomYAxisTick(props: {
   y: number;
   payload: unknown;
   width: number;
@@ -169,7 +177,7 @@ function ThreeWBarChart(props: BarChartProps) {
         styles.chartContainer,
         className
       )}
-      maxHeight={limitHeight ? 30*chartData.length : undefined}
+      maxHeight={limitHeight ? 30 * chartData.length : undefined}
     >
       <BarChart
         layout="vertical"
@@ -205,6 +213,7 @@ function ThreeWBarChart(props: BarChartProps) {
               x: false,
               y: false,
             }}
+            formatter={(value: number) => [value, 'Projects']}
           />
         )}
         <Bar

--- a/src/root/views/GlobalThreeW/Charts/styles.module.scss
+++ b/src/root/views/GlobalThreeW/Charts/styles.module.scss
@@ -23,7 +23,7 @@
 
     .recharts-tooltip-wrapper {
       .recharts-tooltip-label {
-        max-width: 9rem;
+        max-width: 7rem;
         word-wrap: break-word;
         word-break: break-all;
         white-space: initial;

--- a/src/root/views/GlobalThreeW/Map/index.tsx
+++ b/src/root/views/GlobalThreeW/Map/index.tsx
@@ -234,6 +234,7 @@ function GlobalThreeWMap(props: Props) {
       key: p.primary_sector,
       value: p.count,
       name: p.primary_sector_display,
+      Projects: p.count,
     })) ?? [],
     [selectedNsProjectStats?.projects_per_sector]
   );

--- a/src/root/views/GlobalThreeW/index.tsx
+++ b/src/root/views/GlobalThreeW/index.tsx
@@ -232,19 +232,16 @@ function GlobalThreeW(props: Props) {
           <>
             <Card
               title={strings.globalThreeWChartProjectPerSectorTitle}
-              className={styles.projectPerSectorChart}
             >
               <ThreeWBarChart data={projectPerSectorChartData} />
             </Card>
             <Card
               title={strings.globalThreeWChartProgrammeTypeTitle}
-              className={styles.programmeTypeChart}
             >
               <ThreeWPieChart data={projectPerProgrammeTypeChartData} />
             </Card>
             <Card
               title={strings.globalThreeWChartTopTagsTitle}
-              className={styles.topTagsChart}
             >
               <ThreeWBarChart
                 data={projectPerSecondarySectorChartData}
@@ -264,7 +261,7 @@ function GlobalThreeW(props: Props) {
             />
             {(allRegions?.data?.results?.length ?? 0) > 0 && (
               <DropdownMenu
-                label={<div {...exploreRegional3WLinkProps} /> }
+                label={<div {...exploreRegional3WLinkProps} />}
               >
                 {allRegions.data.results.map((region) => (
                   <DropdownMenuItem

--- a/src/root/views/ThreeW/index.tsx
+++ b/src/root/views/ThreeW/index.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react-router-dom';
 import { IoPencil } from 'react-icons/io5';
 
+import Translate from '#components/Translate';
 import TextOutput from '#components/TextOutput';
 import Page from '#components/Page';
 import { useButtonFeatures } from '#components/Button';
@@ -62,6 +63,24 @@ function ThreeW(props: Props) {
     children: strings.threeWEditProject,
   });
 
+  const displayName = React.useMemo(() => {
+    if (!projectDetails?.modified_by_detail) {
+      return undefined;
+    }
+
+    const {
+      username,
+      firstName,
+      lastName,
+    } = projectDetails.modified_by_detail;
+
+    if (firstName) {
+      return `${firstName} ${lastName}`;
+    }
+
+    return username;
+  }, [projectDetails?.modified_by_detail]);
+
   return (
     <Page
       className={_cs(styles.threeWDetails, className)}
@@ -69,14 +88,20 @@ function ThreeW(props: Props) {
       breadCrumbs={<BreadCrumb crumbs={crumbs} compact />}
       heading={projectDetails?.name ?? '--'}
       withMainContentBackground
-      description={(
+      description={projectDetails ? (
         <TextOutput
-          className={styles.lastModifiedDate}
+          className={styles.lastModified}
           label={strings.threeWLastModifiedOn}
           value={projectDetails?.modified_at}
           valueType="date"
+          description={displayName ? (
+            <Translate
+              stringId="threeWLastModifiedBy"
+              params={{ user: displayName }}
+            />
+          ) : undefined}
         />
-      )}
+      ) : undefined }
       actions={(
         <Link
           to={`/three-w/${projectId}/edit/`}

--- a/src/root/views/ThreeW/styles.module.scss
+++ b/src/root/views/ThreeW/styles.module.scss
@@ -5,7 +5,7 @@
     padding: 0;
   }
 
-  .last-modified-date {
+  .last-modified {
     display: flex;
     justify-content: center;
   }

--- a/src/root/views/about.js
+++ b/src/root/views/about.js
@@ -320,7 +320,7 @@ function About (props) {
                           </div>
                         </div>
                         <div className='box__global__content'>
-                          <a href='https://media.ifrc.org/ifrc/what-we-do/reference-centres/' target='_blank' className='box__global__content--ref__link'>
+                          <a href='https://www.ifrc.org/reference-centres/' target='_blank' className='box__global__content--ref__link'>
                             <span>
                               <Translate stringId='aboutReferenceCenters'/>
                             </span>

--- a/src/root/views/deployments.js
+++ b/src/root/views/deployments.js
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { connect } from 'react-redux';
 import { PropTypes as T } from 'prop-types';
 import c from 'classnames';
 import { Helmet } from 'react-helmet';
+
+import { TimeLineChart } from '#components/Charts';
 
 import {
   enterFullscreen,
@@ -17,6 +19,7 @@ import {
   getEruOwners,
   getPersonnelByEvent
 } from '#actions';
+import { useRequest } from '#utils/restRequest';
 import { finishedFetch, datesAgo } from '#utils/utils';
 import { mergeDeployData } from '#utils/mergeDeployData';
 import { showGlobalLoading, hideGlobalLoading } from '#components/global-loading';
@@ -39,6 +42,23 @@ import BreadCrumb from '#components/breadcrumb';
 import LanguageContext from '#root/languageContext';
 import Translate from '#components/Translate';
 import { countriesGeojsonSelector } from '../selectors';
+
+
+const DeploymentsByMonth = () => {
+  const { pending, response } = useRequest({url: 'api/v2/deployment/aggregated_by_month/'});
+
+  const formatData = useCallback((data) => {
+    const keys = Object.keys(data).reverse();
+    return keys.map((key) =>
+      ({ timespan: new Date(key).toISOString(), count: data[key]} )
+    );
+  }, []);
+
+  return (!pending && response)
+    ? <TimeLineChart data={formatData(response)} />
+    : <></>;
+};
+
 
 class Deployments extends SFPComponent {
   // Methods form SFPComponent:
@@ -201,14 +221,19 @@ class Deployments extends SFPComponent {
             <div className='row flex-xs'>
               <div className='col col-6-xs spacing-v'>
                 <div className='chart box__content'>
-                  {this.renderHeaderCharts(data.types, strings.deploymentEruDeploymentTypes)}
+                  {this.renderHeaderCharts(data.owners, strings.deploymentNumber)}
                 </div>
               </div>
               <div className='col col-6-xs spacing-v'>
+                <figure className='chart'>
+                  <figcaption>
+                    <h2 className='fold__title'><Translate stringId='deployementsOverLastYear' /></h2>
+                  </figcaption>
+                </figure>
                 <div className='chart box__content'>
-                  {this.renderHeaderCharts(data.owners, strings.deploymentNumber)}
+                  <DeploymentsByMonth />
                 </div>
-            </div>
+              </div>
             </div>
           </div>
         </div>

--- a/src/root/views/deployments.js
+++ b/src/root/views/deployments.js
@@ -221,20 +221,22 @@ class Deployments extends SFPComponent {
       <div className=''>
         <div className='inner'>
           <div className='inpage__body-charts'>
-            <div className='row flex-xs'>
-              <div className='col col-6-xs spacing-v'>
+            <div className='row display-flex flex-row'>
+              <div className='col col-6-xs spacing-v display-flex'>
                 <div className='chart box__content'>
                   {this.renderHeaderCharts(data.owners, strings.deploymentNumber)}
                 </div>
               </div>
-              <div className='col col-6-xs spacing-v'>
-                <figure className='chart'>
-                  <figcaption>
-                    <h2 className='fold__title'><Translate stringId='deployementsOverLastYear' /></h2>
-                  </figcaption>
-                </figure>
+              <div className='col col-6-xs spacing-v display-flex'>
                 <div className='chart box__content'>
-                  <DeploymentsByMonth />
+                  <figure>
+                    <figcaption>
+                      <h2 className='fold__title'><Translate stringId='deployementsOverLastYear' /></h2>
+                    </figcaption>
+                  </figure>
+                  <div className='spacing-2-t'>
+                    <DeploymentsByMonth />
+                  </div>
                 </div>
               </div>
             </div>

--- a/src/root/views/deployments.js
+++ b/src/root/views/deployments.js
@@ -18,6 +18,7 @@ import {
   getPersonnelByEvent
 } from '#actions';
 import { finishedFetch, datesAgo } from '#utils/utils';
+import { mergeDeployData } from '#utils/mergeDeployData';
 import { showGlobalLoading, hideGlobalLoading } from '#components/global-loading';
 import { environment } from '#config';
 import {
@@ -156,9 +157,9 @@ class Deployments extends SFPComponent {
         <div className='header-stats container-lg'>
           <div className='sumstats__wrap'>
             <ul className='sumstats'>
-              <li className='sumstats__item__wrap'>            
+              <li className='sumstats__item__wrap'>
                 <div className='sumstats__item'>
-                  <img className='sumstats__icon_2020' src='/assets/graphics/layout/eru-brand.svg' /> 
+                  <img className='sumstats__icon_2020' src='/assets/graphics/layout/eru-brand.svg' />
                   <span className='sumstats__value'>
                     {n(data.deployed)}
                   </span>
@@ -222,6 +223,14 @@ class Deployments extends SFPComponent {
     } = this.props.eruOwners;
     const { strings } = this.context;
     if (!fetched || error) return null;
+    let deployData = {type: 'FeatureCollection', features: []};
+    if (this.props.eru.fetched && this.props.activePersonnel.fetched) {
+      deployData = mergeDeployData(
+        this.props.countriesGeojson,
+        this.props.allEru.data.results,
+        this.props.activePersonnel.data.results
+      );
+    }
 
     return (
       <section>
@@ -245,7 +254,7 @@ class Deployments extends SFPComponent {
           </header>
           <div className='container-lg'>
             <DeploymentsMap
-              data={this.props.locations}
+              data={deployData}
               countriesGeojson={this.props.countriesGeojson}
             />
           </div>
@@ -310,15 +319,16 @@ if (environment !== 'production') {
     eruOwners: T.object,
     eru: T.object,
     activePersonnel: T.object,
-    locations: T.object,
+    allEru: T.object,
     countriesGeojson: T.object
   };
 }
 
 const selector = (state) => ({
   eruOwners: state.eruOwners,
+  eru: state.deployments.eru,
   activePersonnel: state.deployments.activePersonnel,
-  locations: state.deployments.locations,
+  allEru: state.deployments.allEru,
   countriesGeojson: countriesGeojsonSelector(state),
   personnelByEvent: state.personnelByEvent
 });

--- a/src/root/views/deployments.js
+++ b/src/root/views/deployments.js
@@ -4,6 +4,7 @@ import { PropTypes as T } from 'prop-types';
 import c from 'classnames';
 import { Helmet } from 'react-helmet';
 
+import BlockLoading from '#components/block-loading';
 import { TimeLineChart } from '#components/Charts';
 
 import {
@@ -283,10 +284,13 @@ class Deployments extends SFPComponent {
             </div>
           </header>
           <div className='container-lg'>
-            <DeploymentsMap
-              data={deployData}
-              countriesGeojson={this.props.countriesGeojson}
-            />
+            {this.props.eru.fetched && this.props.activePersonnel.fetched ?
+              <DeploymentsMap
+                data={deployData}
+                countriesGeojson={this.props.countriesGeojson}
+              />
+              : <BlockLoading />
+            }
           </div>
           <div className='inpage__body container-lg'>
             <div className='inner'>

--- a/src/root/views/deployments.js
+++ b/src/root/views/deployments.js
@@ -276,6 +276,7 @@ class Deployments extends SFPComponent {
               <AlertsTable
                 title={strings.homeSurgeNotification}
                 limit={5}
+                isActive={true}
                 viewAll={'/alerts/all'}
                 showRecent={true}
               />

--- a/src/root/views/deployments.js
+++ b/src/root/views/deployments.js
@@ -143,8 +143,9 @@ class Deployments extends SFPComponent {
   }
 
   renderHeaderCharts (data, title) {
+    const rows = 5;
     const max = Math.max.apply(Math, data.map(o => +o.items));
-    const items = data.length > 6 ? data.slice(0, 6) : data;
+    const items = data.length > rows ? data.slice(0, rows) : data;
     return (
       <div>
         <figcaption>
@@ -292,12 +293,6 @@ class Deployments extends SFPComponent {
           </div>
         </section>
         <div className='inpage__body'>
-          <div className='inner'>
-            <EruTable
-              limit={5}
-              viewAll={'/deployments/erus/all'}
-            />
-          </div>
           <div className='inner margin-4-t'>
             <div>
               <AlertsTable
@@ -310,6 +305,12 @@ class Deployments extends SFPComponent {
             </div>
             <div className='table-deployed-personnel-block'>
               <PersonnelByEventTable data={this.props.personnelByEvent} />
+            </div>
+            <div className='inner'>
+            <EruTable
+              limit={5}
+              viewAll={'/deployments/erus/all'}
+            />
             </div>
             <div className='readiness__container container-lg'>
               <Readiness eruOwners={this.props.eruOwners} />

--- a/src/root/views/deployments.js
+++ b/src/root/views/deployments.js
@@ -17,7 +17,8 @@ import {
   getAllDeploymentERU,
   getActivePersonnel,
   getEruOwners,
-  getPersonnelByEvent
+  getPersonnelByEvent,
+  getAggrSurgeKeyFigures
 } from '#actions';
 import { useRequest } from '#utils/restRequest';
 import { finishedFetch, datesAgo } from '#utils/utils';
@@ -86,6 +87,7 @@ class Deployments extends SFPComponent {
     this.props._getAllDeploymentERU();
     this.props._getActivePersonnel();
     this.props._getPersonnelByEvent();
+    this.props._getAggrSurgeKeyFigures();
   }
 
   // eslint-disable-next-line camelcase
@@ -179,29 +181,29 @@ class Deployments extends SFPComponent {
             <ul className='sumstats'>
               <li className='sumstats__item__wrap'>
                 <div className='sumstats__item'>
-                  <img className='sumstats__icon_2020' src='/assets/graphics/layout/eru-brand.svg' />
+                  <img className='sumstats__icon_2020' src='/assets/graphics/layout/heops-brand.svg' />
                   <span className='sumstats__value'>
-                    {n(data.deployed)}
+                    {n(this.props.aggregated.data.active_deployments)}
                   </span>
-                  <Translate className='sumstats__key' stringId='deploymentsDeployedERU'/>
+                  <Translate className='sumstats__key' stringId='deploymentsDeployedRRP'/>
+                </div>
+              </li>
+              <li className='sumstats__item__wrap'>
+                <div className='sumstats__item'>
+                  <img className='sumstats__icon_2020' src='/assets/graphics/layout/eru-brand.svg'/>
+                  <span className='sumstats__value'>
+                    {n(this.props.aggregated.data.active_erus)}
+                  </span>
+                  <Translate className='sumstats__key' stringId='deploymentsDeployedERU'/> &nbsp;
                 </div>
               </li>
               <li className='sumstats__item__wrap'>
                 <div className='sumstats__item'>
                   <img className='sumstats__icon_2020' src='/assets/graphics/layout/fact-brand.svg' />
                   <span className='sumstats__value'>
-                    {n(fact)}
+                    {n(this.props.aggregated.data.deployments_this_year)}
                   </span>
-                  <Translate className='sumstats__key' stringId='deploymentsDeployedRR'/>
-                </div>
-              </li>
-              <li className='sumstats__item__wrap'>
-                <div className='sumstats__item'>
-                  <img className='sumstats__icon_2020' src='/assets/graphics/layout/heops-brand.svg' />
-                  <span className='sumstats__value'>
-                    {n(heop)}
-                  </span>
-                  <Translate className='sumstats__key' stringId='deploymentsDeployedHeops'/>
+                  <Translate className='sumstats__key' stringId='deploymentsDeplThisYear'/> &nbsp;
                 </div>
               </li>
             </ul>
@@ -356,14 +358,16 @@ const selector = (state) => ({
   activePersonnel: state.deployments.activePersonnel,
   allEru: state.deployments.allEru,
   countriesGeojson: countriesGeojsonSelector(state),
-  personnelByEvent: state.personnelByEvent
+  personnelByEvent: state.personnelByEvent,
+  aggregated: state.deployments.aggregated
 });
 
 const dispatcher = (dispatch) => ({
   _getEruOwners: () => dispatch(getEruOwners()),
   _getAllDeploymentERU: (...args) => dispatch(getAllDeploymentERU(...args)),
   _getActivePersonnel: (...args) => dispatch(getActivePersonnel(...args)),
-  _getPersonnelByEvent: (...args) => dispatch(getPersonnelByEvent(...args))
+  _getPersonnelByEvent: (...args) => dispatch(getPersonnelByEvent(...args)),
+  _getAggrSurgeKeyFigures: () => dispatch(getAggrSurgeKeyFigures())
 });
 
 export default connect(selector, dispatcher)(Deployments);

--- a/src/root/views/emergency.js
+++ b/src/root/views/emergency.js
@@ -1439,7 +1439,7 @@ class Emergency extends React.Component {
                             <div className='sumstats__item'>
                               <img className='sumstats__icon_2020' src='/assets/graphics/layout/heops-brand.svg' />
                               <span className='sumstats__value'>
-                                {n(this.props.aggregated.data.active_deployments)}
+                                {n(this.props.aggregated.active_deployments)}
                               </span>
                               <Translate className='sumstats__key' stringId='deploymentsDeployedRRP'/>
                             </div>
@@ -1448,7 +1448,7 @@ class Emergency extends React.Component {
                             <div className='sumstats__item'>
                               <img className='sumstats__icon_2020' src='/assets/graphics/layout/eru-brand.svg'/>
                               <span className='sumstats__value'>
-                                {n(this.props.aggregated.data.active_erus)}
+                                {n(this.props.aggregated.active_erus)}
                               </span>
                               <Translate className='sumstats__key' stringId='deploymentsDeployedERU'/> &nbsp;
                             </div>
@@ -1457,7 +1457,7 @@ class Emergency extends React.Component {
                             <div className='sumstats__item'>
                               <img className='sumstats__icon_2020' src='/assets/graphics/layout/fact-brand.svg' />
                               <span className='sumstats__value'>
-                                {n(this.props.aggregated.data.deployments_this_year)}
+                                {n(this.props.aggregated.deployments_this_year)}
                               </span>
                               <Translate className='sumstats__key' stringId='deploymentsDeplThisYear'/> &nbsp;
                             </div>
@@ -1594,7 +1594,7 @@ const selector = (state, ownProps) => ({
   regionsById: regionsByIdSelector(state),
   countriesGeojson: countriesGeojsonSelector(state),
   disasterTypes: disasterTypesSelector(state),
-  aggregated: state.event.aggregated
+  aggregated: state.event.aggregated.data
 });
 
 const dispatcher = (dispatch) => ({

--- a/src/root/views/emergency.js
+++ b/src/root/views/emergency.js
@@ -1432,6 +1432,7 @@ class Emergency extends React.Component {
                   <TabContent title={strings.emergencyAlertsTitle}>
                     <SurgeAlertsTable
                       id="alerts"
+                      isActive={true}
                       title={strings.emergencyAlertsTitle}
                       emergency={this.props.match.params.id}
                       returnNullForEmpty={true}

--- a/src/root/views/emergency.js
+++ b/src/root/views/emergency.js
@@ -1439,7 +1439,7 @@ class Emergency extends React.Component {
                             <div className='sumstats__item'>
                               <img className='sumstats__icon_2020' src='/assets/graphics/layout/heops-brand.svg' />
                               <span className='sumstats__value'>
-                                0 {/*n(this.props.aggregated.active_deployments)*/}
+                                {n(this.props.aggregated.data.active_deployments)}
                               </span>
                               <Translate className='sumstats__key' stringId='deploymentsDeployedRRP'/>
                             </div>
@@ -1448,7 +1448,7 @@ class Emergency extends React.Component {
                             <div className='sumstats__item'>
                               <img className='sumstats__icon_2020' src='/assets/graphics/layout/eru-brand.svg'/>
                               <span className='sumstats__value'>
-                                0 {/*n(this.props.aggregated.active_erus)*/}
+                                {n(this.props.aggregated.data.active_erus)}
                               </span>
                               <Translate className='sumstats__key' stringId='deploymentsDeployedERU'/> &nbsp;
                             </div>
@@ -1457,7 +1457,7 @@ class Emergency extends React.Component {
                             <div className='sumstats__item'>
                               <img className='sumstats__icon_2020' src='/assets/graphics/layout/fact-brand.svg' />
                               <span className='sumstats__value'>
-                                0 {/* n(this.props.aggregated.deployments_this_year)*/}
+                                {n(this.props.aggregated.data.deployments_this_year)}
                               </span>
                               <Translate className='sumstats__key' stringId='deploymentsDeplThisYear'/> &nbsp;
                             </div>
@@ -1594,7 +1594,7 @@ const selector = (state, ownProps) => ({
   regionsById: regionsByIdSelector(state),
   countriesGeojson: countriesGeojsonSelector(state),
   disasterTypes: disasterTypesSelector(state),
-  aggregated: state.event.aggregated.data
+  aggregated: state.deployments.aggregated1
 });
 
 const dispatcher = (dispatch) => ({

--- a/src/root/views/emergency.js
+++ b/src/root/views/emergency.js
@@ -1453,15 +1453,6 @@ class Emergency extends React.Component {
                               <Translate className='sumstats__key' stringId='deploymentsDeployedERU'/> &nbsp;
                             </div>
                           </li>
-                          <li className='sumstats__item__wrap'>
-                            <div className='sumstats__item'>
-                              <img className='sumstats__icon_2020' src='/assets/graphics/layout/fact-brand.svg' />
-                              <span className='sumstats__value'>
-                                {n(this.props.aggregated.data.deployments_this_year)}
-                              </span>
-                              <Translate className='sumstats__key' stringId='deploymentsDeplThisYear'/> &nbsp;
-                            </div>
-                          </li>
                         </ul>
                       </div>
                     </div>
@@ -1476,15 +1467,6 @@ class Emergency extends React.Component {
                       viewAll='/alerts/all'
                     />
                   </TabContent>
-                  <TabContent
-                    title={strings.emergencyERUTitle}
-                  >
-                    <EruTable
-                      id="erus"
-                      emergency={this.props.match.params.id}
-                      viewAll='/deployments/erus/all'
-                    />
-                  </TabContent>
                   <TabContent title={strings.emergencyPersonnelTitle}>
                     { this.state.hasPersonnel ? (
                       <PersonnelTable
@@ -1493,6 +1475,15 @@ class Emergency extends React.Component {
                         viewAll='/deployments/personnel/all'
                       />
                     ) : null }
+                  </TabContent>
+                  <TabContent
+                    title={strings.emergencyERUTitle}
+                  >
+                    <EruTable
+                      id="erus"
+                      emergency={this.props.match.params.id}
+                      viewAll='/deployments/erus/all'
+                    />
                   </TabContent>
                 </TabPanel>
                 ) : null }

--- a/src/root/views/emergency.js
+++ b/src/root/views/emergency.js
@@ -27,7 +27,8 @@ import {
   addSubscriptions,
   delSubscription,
   getUserProfile,
-  getDeploymentERU
+  getDeploymentERU,
+  getAggrSurgeEventKeyFigures
 } from '#actions';
 import {
   commaSeparatedNumber as n,
@@ -145,6 +146,7 @@ class Emergency extends React.Component {
 
   componentDidMount () {
     this.getEvent(this.props.match.params.id);
+    this.props._getAggrSurgeEventKeyFigures(this.props.match.params.id);
     this.props._getSitrepTypes();
     if (this.props.isLogged) {
       this.props._getUserProfile(this.props.user.data.username);
@@ -1429,6 +1431,41 @@ class Emergency extends React.Component {
 
                 { this.hasRRTab() ? (
                 <TabPanel>
+                  <div>
+                    <div className='header-stats container-lg'>
+                      <div className='sumstats__wrap'>
+                        <ul className='sumstats'>
+                          <li className='sumstats__item__wrap'>
+                            <div className='sumstats__item'>
+                              <img className='sumstats__icon_2020' src='/assets/graphics/layout/heops-brand.svg' />
+                              <span className='sumstats__value'>
+                                {n(this.props.aggregated.data.active_deployments)}
+                              </span>
+                              <Translate className='sumstats__key' stringId='deploymentsDeployedRRP'/>
+                            </div>
+                          </li>
+                          <li className='sumstats__item__wrap'>
+                            <div className='sumstats__item'>
+                              <img className='sumstats__icon_2020' src='/assets/graphics/layout/eru-brand.svg'/>
+                              <span className='sumstats__value'>
+                                {n(this.props.aggregated.data.active_erus)}
+                              </span>
+                              <Translate className='sumstats__key' stringId='deploymentsDeployedERU'/> &nbsp;
+                            </div>
+                          </li>
+                          <li className='sumstats__item__wrap'>
+                            <div className='sumstats__item'>
+                              <img className='sumstats__icon_2020' src='/assets/graphics/layout/fact-brand.svg' />
+                              <span className='sumstats__value'>
+                                {n(this.props.aggregated.data.deployments_this_year)}
+                              </span>
+                              <Translate className='sumstats__key' stringId='deploymentsDeplThisYear'/> &nbsp;
+                            </div>
+                          </li>
+                        </ul>
+                      </div>
+                    </div>
+                  </div>
                   <TabContent title={strings.emergencyAlertsTitle}>
                     <SurgeAlertsTable
                       id="alerts"
@@ -1556,7 +1593,8 @@ const selector = (state, ownProps) => ({
   profile: state.profile,
   regionsById: regionsByIdSelector(state),
   countriesGeojson: countriesGeojsonSelector(state),
-  disasterTypes: disasterTypesSelector(state)
+  disasterTypes: disasterTypesSelector(state),
+  aggregated: state.event.aggregated
 });
 
 const dispatcher = (dispatch) => ({
@@ -1572,6 +1610,7 @@ const dispatcher = (dispatch) => ({
   _addSubscriptions: (...args) => dispatch(addSubscriptions(...args)),
   _delSubscription: (...args) => dispatch(delSubscription(...args)),
   _getUserProfile: (...args) => dispatch(getUserProfile(...args)),
+  _getAggrSurgeEventKeyFigures: (...args) => dispatch(getAggrSurgeEventKeyFigures(...args))
 });
 
 export default withLanguage(withRouter(connect(selector, dispatcher)(Emergency)));

--- a/src/root/views/emergency.js
+++ b/src/root/views/emergency.js
@@ -1439,7 +1439,7 @@ class Emergency extends React.Component {
                             <div className='sumstats__item'>
                               <img className='sumstats__icon_2020' src='/assets/graphics/layout/heops-brand.svg' />
                               <span className='sumstats__value'>
-                                {n(this.props.aggregated.active_deployments)}
+                                0 {/*n(this.props.aggregated.active_deployments)*/}
                               </span>
                               <Translate className='sumstats__key' stringId='deploymentsDeployedRRP'/>
                             </div>
@@ -1448,7 +1448,7 @@ class Emergency extends React.Component {
                             <div className='sumstats__item'>
                               <img className='sumstats__icon_2020' src='/assets/graphics/layout/eru-brand.svg'/>
                               <span className='sumstats__value'>
-                                {n(this.props.aggregated.active_erus)}
+                                0 {/*n(this.props.aggregated.active_erus)*/}
                               </span>
                               <Translate className='sumstats__key' stringId='deploymentsDeployedERU'/> &nbsp;
                             </div>
@@ -1457,7 +1457,7 @@ class Emergency extends React.Component {
                             <div className='sumstats__item'>
                               <img className='sumstats__icon_2020' src='/assets/graphics/layout/fact-brand.svg' />
                               <span className='sumstats__value'>
-                                {n(this.props.aggregated.deployments_this_year)}
+                                0 {/* n(this.props.aggregated.deployments_this_year)*/}
                               </span>
                               <Translate className='sumstats__key' stringId='deploymentsDeplThisYear'/> &nbsp;
                             </div>

--- a/src/root/views/table.js
+++ b/src/root/views/table.js
@@ -79,7 +79,11 @@ class Table extends React.Component {
         const title = props.hasOwnProperty('record')
           ? strings.operationsWithEmergency
           : resolveToString(strings.tableAppealsTitle, { title: titleArea, noun: noun });
-      return <AppealsTable title={title} {...props} />;
+      return (<AppealsTable
+        isActive={false}
+        title={title} 
+        {...props}
+      />);
       case 'alert':
       return <AlertsTable title={strings.tableAllAlertsTitle} {...props} />;
       case 'eru':

--- a/src/styles/components/_common.scss
+++ b/src/styles/components/_common.scss
@@ -7,7 +7,6 @@
   }
 
   .mapboxgl-popup {
-    height: 14rem;
     width: 20rem;
     overflow: auto;
 
@@ -275,7 +274,7 @@
     padding-top: 0;
   }
 }
-  
+
 .table__cell--progress__personnel {
   width: 40%;
   padding-inline-start: 0;
@@ -301,7 +300,7 @@
 
 .fold__table--deploy-personnel {
   .fold__body {
-    position: relative;  
+    position: relative;
   }
 }
 
@@ -330,7 +329,7 @@
 .personnel__table__date__current {
   display: flex;
   font-size: $font-size-xs;
-  font-weight: $base-font-medium;  
+  font-weight: $base-font-medium;
   width: 40%;
   position: relative;
   top: 37px;

--- a/src/styles/core/_grid.scss
+++ b/src/styles/core/_grid.scss
@@ -130,7 +130,7 @@
 // Row: Mixin
 @mixin row($grid-gutter: $grid-gutter) {
   margin-left: -$grid-gutter;
-  margin-right: -$grid-gutter;   
+  margin-right: -$grid-gutter;
   @include clearfix;
 }
 
@@ -152,7 +152,7 @@
 
 // ---------------------------------------------
 // GRID: COLUMNS
-//  - Wrap in a row: 
+//  - Wrap in a row:
 //  - Columns create gutters
 //  - All parameters have defaults
 //  - Parameters:
@@ -207,15 +207,15 @@
 // Generates classes for 12 columns
 
 // Classes: Default
-// E.g., .col-1, .col-12 
+// E.g., .col-1, .col-12
 @for $i from 1 through $grid-column-count {
-  .col-#{$i} { 
+  .col-#{$i} {
     width: percentage($i / $grid-column-count);
   }
 }
 
 // Classes: Extra Small Breakpoint
-// E.g., .col-1-xs, .col-12-xs 
+// E.g., .col-1-xs, .col-12-xs
 @include media (xsmall) {
   @for $i from 1 through $grid-column-count {
     .col-#{$i}-xs {
@@ -225,7 +225,7 @@
 }
 
 // Classes: Small Breakpoint
-// E.g., .col-1-sm, .col-12-sm 
+// E.g., .col-1-sm, .col-12-sm
 @include media(small) {
   @for $i from 1 through $grid-column-count {
     .col-#{$i}-sm {
@@ -235,7 +235,7 @@
 }
 
 // Classes: Medium Breakpoint
-// E.g., .col-1-mid, .col-12-mid 
+// E.g., .col-1-mid, .col-12-mid
 @include media(medium) {
   @for $i from 1 through $grid-column-count {
     .col-#{$i}-mid {
@@ -245,7 +245,7 @@
 }
 
 // Classes: Large Breakpoint
-// E.g., .col-1-lg, .col-12-lg 
+// E.g., .col-1-lg, .col-12-lg
 @include media(large) {
   @for $i from 1 through $grid-column-count {
     .col-#{$i}-lg {
@@ -314,6 +314,14 @@
 
 .flex-align-baseline {
   align-items: baseline;
+}
+
+.flex-row {
+  flex-direction: row;
+}
+
+.display-flex {
+  display: flex;
 }
 
 .flex-1 {

--- a/src/styles/home/_global.scss
+++ b/src/styles/home/_global.scss
@@ -458,7 +458,7 @@
   [dir='rtl'] & {
     background-position: left 0.5rem center;
   }
-  
+
   &:hover {
     opacity: 1;
   }

--- a/src/styles/settings/_variables.scss
+++ b/src/styles/settings/_variables.scss
@@ -43,7 +43,7 @@ $success-color: #009896;              // Turquoise
 $warning-color: #f39c12;              // Yellow
 $info-color: $secondary-color;        // Blue
 $light-base-color: #666666;
-$state-low: #60c460;
+$state-low: #fFee00;
 $state-mid: #ff5014;
 $state-high: $primary-color;
 


### PR DESCRIPTION
### Release 5.4.0: 3w Improvements + Surge / Deployments

### Frontend:

 - Re-write Deployments map: https://github.com/IFRCGo/go-frontend/pull/2012
 - Add new chart for Deployments over the Past Year: https://github.com/IFRCGo/go-frontend/pull/2018
 - Update Key Figures on Deployments page: https://github.com/IFRCGo/go-frontend/issues/2011
 - Add Key Figures to Surge tab on Emergency page: https://github.com/IFRCGo/go-frontend/issues/2011
 - Miscellaneous updates to Surge page and tables as per https://github.com/IFRCGo/go-frontend/issues/1965
 - Various improvements to 3w as per https://github.com/IFRCGo/go-frontend/issues/1970

### Backend:

 - Backend changes for 3w as per https://github.com/IFRCGo/go-frontend/issues/1970
 - Upgrade xml2dict library
 - For Surge Alert API, by default return all Alerts, not only Active
 - Fix aggregation count for Events by Deployment endpoint

cc @tovari @LukeCaley @frozenhelium @szabozoltan69 @vdeak 