### PR TITLE
Hotfix for ERUs not showing on the map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Release 5.4.1: Hotfix for Surge Map
+
+Hotfix for ERUs not showing on the map.
+
 ### Release 5.4.0: 3w Improvements + Surge / Deployments
 
 Date: 2021-09-07

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "go-frontend",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "private": true,
   "devDependencies": {
     "@babel/core": "7.9.0",

--- a/src/root/views/deployments.js
+++ b/src/root/views/deployments.js
@@ -255,10 +255,11 @@ class Deployments extends SFPComponent {
     const { strings } = this.context;
     if (!fetched || error) return null;
     let deployData = {type: 'FeatureCollection', features: []};
+    
     if (this.props.eru.fetched && this.props.activePersonnel.fetched) {
       deployData = mergeDeployData(
         this.props.countriesGeojson,
-        this.props.allEru.data.results,
+        this.props.eru.data.results,
         this.props.activePersonnel.data.results
       );
     }


### PR DESCRIPTION
Hotfix for ERUs not displaying on the map.

The logic for fetching the different ERU information does seem a bit convoluted and we should inspect it better.

This fixes the display on the map though.

cc @szabozoltan69 