### PR TITLE
fix specificity of selector so padding 0 applies on deployment graphs

### DIFF
--- a/src/styles/components/_common.scss
+++ b/src/styles/components/_common.scss
@@ -275,7 +275,7 @@
   }
 }
 
-.table__cell--progress__personnel {
+.table .table__cell--progress__personnel {
   width: 40%;
   padding-inline-start: 0;
 }


### PR DESCRIPTION
Should fix the positioning of the Today line in the Deployments chart.

Refs #2057 

cc @szabozoltan69 could you test and let know if this seems to fix? Thanks!