### PR TITLE
show country_to from individual personnel table, refs #2179

### DIFF
--- a/src/root/components/connected/personnel-table.js
+++ b/src/root/components/connected/personnel-table.js
@@ -240,7 +240,7 @@ class PersonnelTable extends SFPComponent {
                         </div>
                         <div class="row-sm spacing-half-b flex">
                           <div class="col-sm">Deployed To</div>
-                          <div class="col-sm base-font-semi-bold">${o.country_to.name}</div>
+                          <div class="col-sm base-font-semi-bold">${o.country_to ? o.country_to.name : o.deployment.country_deployed_to.name}</div>
                         </div>
                       `}
                       //data-for='{`${o.id}`}'         

--- a/src/root/components/connected/personnel-table.js
+++ b/src/root/components/connected/personnel-table.js
@@ -240,7 +240,7 @@ class PersonnelTable extends SFPComponent {
                         </div>
                         <div class="row-sm spacing-half-b flex">
                           <div class="col-sm">Deployed To</div>
-                          <div class="col-sm base-font-semi-bold">${o.deployment.country_deployed_to.name}</div>
+                          <div class="col-sm base-font-semi-bold">${o.country_to.name}</div>
                         </div>
                       `}
                       //data-for='{`${o.id}`}'         


### PR DESCRIPTION
Shows the Country Deployed to from the Personnel table, that comes from Molnix.

If that data does not exist, it falls back to showing the country of the emergency the deployment is associated with, so should continue working for old data.

cc @szabozoltan69 there do not seem to be any deployments in staging so was having a hard time testing this exactly. We may need to create some deployments in Molnix and simulate on staging to test that this works as intended - cc @anamariaescobar .

