### PR TITLE
force padding-left and right to 0 for personnel table cell, refs #2262

### DIFF
--- a/src/styles/components/_common.scss
+++ b/src/styles/components/_common.scss
@@ -278,6 +278,8 @@
 .table__cell--progress__personnel {
   width: 40%;
   padding-inline-start: 0;
+  padding-left: 0 !important;
+  padding-right: 0 !important;
 }
 
 .progress__block__personnel {


### PR DESCRIPTION
There's probably a better way to do this than using `!important` . This does seem to definitively fix the issue though.

I'm going to go ahead and merge and hot fix this. But would be good to look and see how to perhaps do this cleaner.

cc @imohkay @szabozoltan69 