### PR TITLE
dont go into infinite loop in componentWillReceiveProps

### DIFF
--- a/src/root/views/resend-validation.js
+++ b/src/root/views/resend-validation.js
@@ -34,7 +34,7 @@ class ResendValidation extends React.Component {
   UNSAFE_componentWillReceiveProps (nextProps) {
     if (this.state.hasTokens) { return; }
     hideGlobalLoading();
-    if (nextProps.resendValidation.fetched) {
+    if (nextProps.resendValidation.fetched && !this.props.resendValidation.fetched) {
       if (nextProps.resendValidation.error) {   
         showAlert('danger', <p><Translate stringId="resendValidationErrorMessage" params={{message: nextProps.resendValidation.error.error_message}} /></p>, true, 7000);
       } else {


### PR DESCRIPTION
@szabozoltan69 would you be able to test if this seems to fix the issue?

The problem is that `showAlert` also modified the props, causing the `componentWillReceiveProps` to be called in an infinite loop. We should only do that the "first" time the validation data is fetched and not every time. This should handle that.

In general, this `componentWillReceiveProps` stuff is not very good - hopefully we will be able to migrate to the new React Hooks stuff soon.