### PR TITLE
Using districts_details (instead districts) on EmergencyThreeWForm

### DIFF
--- a/src/root/components/EmergencyThreeWForm/index.tsx
+++ b/src/root/components/EmergencyThreeWForm/index.tsx
@@ -128,7 +128,7 @@ function transformResponseToFormFields(response: EmergencyProjectResponse) {
   const formValues: PartialForm<EmergencyThreeWFormFields> = {
     title: response.title,
     country: response.country,
-    districts: response.districts,
+    districts: response.districts_details.map((d) => d.id),
     status: response.status,
     event: response.event,
     start_date: response.start_date,


### PR DESCRIPTION
Refers to https://github.com/IFRCGo/go-frontend/issues/2467